### PR TITLE
Adds Order to signers

### DIFF
--- a/Digipost.Signature.Api.Client.Core.Tests/Smoke/SmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/Smoke/SmokeTests.cs
@@ -13,7 +13,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests.Smoke
                     return Client.DifiQa;
                 }
 
-                return Client.Localhost;
+                return Client.DifiQa;
             }
         }
 

--- a/Digipost.Signature.Api.Client.Core/Signer.cs
+++ b/Digipost.Signature.Api.Client.Core/Signer.cs
@@ -9,6 +9,6 @@
 
         public string PersonalIdentificationNumber { get; }
 
-        public int Order { get; set; }
+        public int? Order { get; set; } = null;
     }
 }

--- a/Digipost.Signature.Api.Client.Core/Signer.cs
+++ b/Digipost.Signature.Api.Client.Core/Signer.cs
@@ -8,5 +8,7 @@
         }
 
         public string PersonalIdentificationNumber { get; }
+
+        public int Order { get; set; }
     }
 }

--- a/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
@@ -98,8 +98,8 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                     },
                     signers = new[]
                     {
-                        new signer {personalidentificationnumber = source.Signers.ElementAt(0).PersonalIdentificationNumber, order = "1"},
-                        new signer {personalidentificationnumber = source.Signers.ElementAt(1).PersonalIdentificationNumber, order = "2"}
+                        new signer {personalidentificationnumber = source.Signers.ElementAt(0).PersonalIdentificationNumber, order = 1},
+                        new signer {personalidentificationnumber = source.Signers.ElementAt(1).PersonalIdentificationNumber, order = 2}
                     }
                 };
 

--- a/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
@@ -44,30 +44,6 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
             }
 
             [TestMethod]
-            public void ConvertsPortalJobWithOrderedSignersSuccessfully()
-            {
-                //Arrange
-                var document = CoreDomainUtility.GetDocument();
-                var signers = new List<Signer> {new Signer("")};
-                var reference = "reference";
-                var source = new PortalJob(document, signers, reference);
-
-                var expected = new portalsignaturejobrequest
-                {
-                    reference = reference
-                };
-
-                //Act
-                var result = DataTransferObjectConverter.ToDataTransferObject(source);
-
-                //Assert
-                var comparator = new Comparator();
-                IEnumerable<IDifference> differences;
-                comparator.AreEqual(expected, result, out differences);
-                Assert.AreEqual(0, differences.Count());
-            }
-
-            [TestMethod]
             public void ConvertsManifestWithoutAvailabilitySuccessfully()
             {
                 //Arrange

--- a/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
@@ -44,6 +44,30 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
             }
 
             [TestMethod]
+            public void ConvertsPortalJobWithOrderedSignersSuccessfully()
+            {
+                //Arrange
+                var document = CoreDomainUtility.GetDocument();
+                var signers = new List<Signer> {new Signer("")};
+                var reference = "reference";
+                var source = new PortalJob(document, signers, reference);
+
+                var expected = new portalsignaturejobrequest
+                {
+                    reference = reference
+                };
+
+                //Act
+                var result = DataTransferObjectConverter.ToDataTransferObject(source);
+
+                //Assert
+                var comparator = new Comparator();
+                IEnumerable<IDifference> differences;
+                comparator.AreEqual(expected, result, out differences);
+                Assert.AreEqual(0, differences.Count());
+            }
+
+            [TestMethod]
             public void ConvertsManifestWithoutAvailabilitySuccessfully()
             {
                 //Arrange
@@ -65,6 +89,41 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                     {
                         new signer {personalidentificationnumber = source.Signers.ElementAt(0).PersonalIdentificationNumber},
                         new signer {personalidentificationnumber = source.Signers.ElementAt(1).PersonalIdentificationNumber}
+                    }
+                };
+
+                //Act
+                var result = DataTransferObjectConverter.ToDataTransferObject(source);
+
+                //Assert
+                var comparator = new Comparator();
+                IEnumerable<IDifference> differences;
+                comparator.AreEqual(expected, result, out differences);
+                Assert.AreEqual(0, differences.Count());
+            }
+
+            [TestMethod]
+            public void ConvertsManifestWithOrderedSignersSuccessfully()
+            {
+                //Arrange
+                const string organizationNumberSender = "12345678902";
+
+                var source = new PortalManifest(new Sender(organizationNumberSender), CoreDomainUtility.GetDocument(), new List<Signer> {new Signer("00000000000") {Order = 1}, new Signer("99999999999") {Order = 2}});
+
+                var expected = new portalsignaturejobmanifest
+                {
+                    sender = new sender {organizationnumber = organizationNumberSender},
+                    document = new document
+                    {
+                        title = source.Document.Subject,
+                        description = source.Document.Message,
+                        href = source.Document.FileName,
+                        mime = source.Document.MimeType
+                    },
+                    signers = new[]
+                    {
+                        new signer {personalidentificationnumber = source.Signers.ElementAt(0).PersonalIdentificationNumber, order = "1"},
+                        new signer {personalidentificationnumber = source.Signers.ElementAt(1).PersonalIdentificationNumber, order = "2"}
                     }
                 };
 

--- a/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
@@ -52,11 +52,17 @@ namespace Digipost.Signature.Api.Client.Portal.DataTransferObjects
 
         private static signer ToDataTransferObject(Signer signer)
         {
-            return new signer
+            var dataTransferObject = new signer
             {
-                personalidentificationnumber = signer.PersonalIdentificationNumber,
-                order = signer.Order?.ToString()
+                personalidentificationnumber = signer.PersonalIdentificationNumber
             };
+
+            if (signer.Order != null)
+            {
+                dataTransferObject.order = signer.Order.Value;
+            }
+
+            return dataTransferObject;
         }
 
         public static sender ToDataTransferObject(Sender sender)

--- a/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
@@ -54,7 +54,8 @@ namespace Digipost.Signature.Api.Client.Portal.DataTransferObjects
         {
             return new signer
             {
-                personalidentificationnumber = signer.PersonalIdentificationNumber
+                personalidentificationnumber = signer.PersonalIdentificationNumber,
+                order = signer.Order.ToString()
             };
         }
 

--- a/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
@@ -55,7 +55,7 @@ namespace Digipost.Signature.Api.Client.Portal.DataTransferObjects
             return new signer
             {
                 personalidentificationnumber = signer.PersonalIdentificationNumber,
-                order = signer.Order.ToString()
+                order = signer.Order?.ToString()
             };
         }
 

--- a/Digipost.Signature.Api.Client.Scripts/XsdToCode/Code/direct-and-portal.cs
+++ b/Digipost.Signature.Api.Client.Scripts/XsdToCode/Code/direct-and-portal.cs
@@ -320,6 +320,8 @@ public partial class signer {
     
     private string personalidentificationnumberField;
     
+    private string orderField;
+    
     /// <remarks/>
     [System.Xml.Serialization.XmlElementAttribute("personal-identification-number")]
     public string personalidentificationnumber {
@@ -328,6 +330,17 @@ public partial class signer {
         }
         set {
             this.personalidentificationnumberField = value;
+        }
+    }
+    
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute(DataType="integer")]
+    public string order {
+        get {
+            return this.orderField;
+        }
+        set {
+            this.orderField = value;
         }
     }
 }

--- a/Digipost.Signature.Api.Client.Scripts/XsdToCode/Code/direct-and-portal.cs
+++ b/Digipost.Signature.Api.Client.Scripts/XsdToCode/Code/direct-and-portal.cs
@@ -320,7 +320,9 @@ public partial class signer {
     
     private string personalidentificationnumberField;
     
-    private string orderField;
+    private int orderField;
+    
+    private bool orderFieldSpecified;
     
     /// <remarks/>
     [System.Xml.Serialization.XmlElementAttribute("personal-identification-number")]
@@ -334,13 +336,24 @@ public partial class signer {
     }
     
     /// <remarks/>
-    [System.Xml.Serialization.XmlAttributeAttribute(DataType="integer")]
-    public string order {
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public int order {
         get {
             return this.orderField;
         }
         set {
             this.orderField = value;
+        }
+    }
+    
+    /// <remarks/>
+    [System.Xml.Serialization.XmlIgnoreAttribute()]
+    public bool orderSpecified {
+        get {
+            return this.orderFieldSpecified;
+        }
+        set {
+            this.orderFieldSpecified = value;
         }
     }
 }

--- a/Digipost.Signature.Api.Client.Scripts/XsdToCode/Xsd/common.xsd
+++ b/Digipost.Signature.Api.Client.Scripts/XsdToCode/Xsd/common.xsd
@@ -73,7 +73,7 @@
                 </xs:documentation>
             </xs:annotation>
             <xs:simpleType>
-                <xs:restriction base="xs:integer">
+                <xs:restriction base="xs:int">
                     <xs:minInclusive value="0"/>
                     <xs:maxInclusive value="9"/>
                 </xs:restriction>

--- a/Digipost.Signature.Api.Client.Scripts/XsdToCode/Xsd/common.xsd
+++ b/Digipost.Signature.Api.Client.Scripts/XsdToCode/Xsd/common.xsd
@@ -59,6 +59,26 @@
             <xs:element name="personal-identification-number" minOccurs="1" maxOccurs="1"
                         type="personal-identification-number"/>
         </xs:sequence>
+        <xs:attribute name="order" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the order in which documents should be activated. Lower values indicates earlier activation.
+                    A document with higher order will only be made available when all lower order signers have signed the document.
+                    If two signers have the same order, the document will be made available to both in parallell.
+                    Specifying order with only one signer has no effect.
+
+                    The specified signature deadline for portal jobs will be for each individual signer.
+                    For example, 1 day for 3 chained signers means 3 days maximum. The time only runs once for signers in paralell,
+                    so three paralell signers with 1 day deadline will maximum take 1 day.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:integer">
+                    <xs:minInclusive value="0"/>
+                    <xs:maxInclusive value="9"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:simpleType name="personal-identification-number">


### PR DESCRIPTION
It is now possible to order signers by setting `Signer.Order`.