### PR TITLE
Enum to dto fix

### DIFF
--- a/Digipost.Signature.Api.Client.Direct.Tests/DirectJobStatusResponseTests.cs
+++ b/Digipost.Signature.Api.Client.Direct.Tests/DirectJobStatusResponseTests.cs
@@ -15,7 +15,7 @@ namespace Digipost.Signature.Api.Client.Direct.Tests
             {
                 //Arrange
                 var jobId = 22;
-                var jobStatus = JobStatus.Cancelled;
+                var jobStatus = JobStatus.Failed;
                 var jobReferences = DomainUtility.GetJobReferences();
 
                 //Act

--- a/Digipost.Signature.Api.Client.Direct.Tests/Smoke/DirectClientSmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Smoke/DirectClientSmokeTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Web;
-using Difi.Felles.Utility;
 using Digipost.Signature.Api.Client.Core;
 using Digipost.Signature.Api.Client.Core.Tests.Smoke;
 using Digipost.Signature.Api.Client.Core.Tests.Utilities;
@@ -90,7 +88,7 @@ namespace Digipost.Signature.Api.Client.Direct.Tests.Smoke
                 var directJobResponse = directClient.Create(directJob).Result;
                 var statusQueryToken = AutoSignAndGetToken(directClient, directJobResponse).Result;
                 _statusReference = MorphStatusReferenceIfMayBe(directJobResponse.ResponseUrls.Status(statusQueryToken));
-                
+
                 var jobStatusResponse = directClient.GetStatus(_statusReference).Result;
 
                 var directJobStatusResponse = MorphDirectJobStatusResponseIfMayBe(jobStatusResponse);

--- a/Digipost.Signature.Api.Client.Direct.Tests/Utilities/DomainUtility.cs
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Utilities/DomainUtility.cs
@@ -35,7 +35,7 @@ namespace Digipost.Signature.Api.Client.Direct.Tests.Utilities
         public static DirectJobStatusResponse GetDirectJobStatusResponse()
         {
             var jobId = 22;
-            var jobStatus = JobStatus.Cancelled;
+            var jobStatus = JobStatus.Failed;
             var statusResponseUrls = GetJobReferences();
 
             return new DirectJobStatusResponse(

--- a/Digipost.Signature.Api.Client.Direct/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Direct/DataTransferObjects/DataTransferObjectConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Digipost.Signature.Api.Client.Core;
 using Digipost.Signature.Api.Client.Direct.Enums;
+using Digipost.Signature.Api.Client.Direct.Extensions;
 using Digipost.Signature.Api.Client.Direct.Internal.AsicE;
 
 namespace Digipost.Signature.Api.Client.Direct.DataTransferObjects
@@ -40,19 +41,11 @@ namespace Digipost.Signature.Api.Client.Direct.DataTransferObjects
 
         public static DirectJobStatusResponse FromDataTransferObject(directsignaturejobstatusresponse directsignaturejobstatusresponse)
         {
-            var jobStatus = (JobStatus) Enum.Parse(typeof (JobStatus), directsignaturejobstatusresponse.status.ToString(), true);
+            var jobStatus = directsignaturejobstatusresponse.status.ToJobStatus();
 
-            JobReferences jobReferences;
-
-            if (jobStatus == JobStatus.Signed)
-            {
-                jobReferences = new JobReferences(new Uri(directsignaturejobstatusresponse.confirmationurl), new Uri(directsignaturejobstatusresponse.xadesurl), new Uri(directsignaturejobstatusresponse.padesurl)
-                    );
-            }
-            else
-            {
-                jobReferences = new JobReferences(null, null, null);
-            }
+            var jobReferences = jobStatus == JobStatus.Signed 
+                ? new JobReferences(new Uri(directsignaturejobstatusresponse.confirmationurl), new Uri(directsignaturejobstatusresponse.xadesurl), new Uri(directsignaturejobstatusresponse.padesurl)) 
+                : new JobReferences(null, null, null);
 
             return new DirectJobStatusResponse(directsignaturejobstatusresponse.signaturejobid, jobStatus, jobReferences);
         }

--- a/Digipost.Signature.Api.Client.Direct/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Direct/DataTransferObjects/DataTransferObjectConverter.cs
@@ -43,8 +43,8 @@ namespace Digipost.Signature.Api.Client.Direct.DataTransferObjects
         {
             var jobStatus = directsignaturejobstatusresponse.status.ToJobStatus();
 
-            var jobReferences = jobStatus == JobStatus.Signed 
-                ? new JobReferences(new Uri(directsignaturejobstatusresponse.confirmationurl), new Uri(directsignaturejobstatusresponse.xadesurl), new Uri(directsignaturejobstatusresponse.padesurl)) 
+            var jobReferences = jobStatus == JobStatus.Signed
+                ? new JobReferences(new Uri(directsignaturejobstatusresponse.confirmationurl), new Uri(directsignaturejobstatusresponse.xadesurl), new Uri(directsignaturejobstatusresponse.padesurl))
                 : new JobReferences(null, null, null);
 
             return new DirectJobStatusResponse(directsignaturejobstatusresponse.signaturejobid, jobStatus, jobReferences);

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -67,6 +67,7 @@
     <Compile Include="..\SolutionItems\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Extensions\EnumExtensions.cs" />
     <Compile Include="Internal\AsicE\DirectAsiceGenerator.cs" />
     <Compile Include="Internal\DirectCreateAction.cs" />
     <Compile Include="DataTransferObjects\DataTransferObjectConverter.cs" />
@@ -78,7 +79,6 @@
     <Compile Include="RedirectReference.cs" />
     <Compile Include="StatusReference.cs" />
     <Compile Include="DirectJobResponse.cs" />
-    <Compile Include="DirectJobStatus.cs" />
     <Compile Include="ExitUrls.cs" />
     <Compile Include="Enums\JobStatus.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Digipost.Signature.Api.Client.Direct/DirectJobStatus.cs
+++ b/Digipost.Signature.Api.Client.Direct/DirectJobStatus.cs
@@ -1,6 +1,0 @@
-﻿namespace Digipost.Signature.Api.Client.Direct
-{
-    internal class DirectJobStatus
-    {
-    }
-}

--- a/Digipost.Signature.Api.Client.Direct/Enums/JobStatus.cs
+++ b/Digipost.Signature.Api.Client.Direct/Enums/JobStatus.cs
@@ -2,7 +2,7 @@
 {
     public enum JobStatus
     {
-        Cancelled,
+        Failed,
         Rejected,
         Signed
     }

--- a/Digipost.Signature.Api.Client.Direct/Extensions/EnumExtensions.cs
+++ b/Digipost.Signature.Api.Client.Direct/Extensions/EnumExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Digipost.Signature.Api.Client.Direct.Enums;
+
+namespace Digipost.Signature.Api.Client.Direct.Extensions
+{
+    public static class EnumExtensions
+    {
+        public static JobStatus ToJobStatus(this directsignaturejobstatus status)
+        {
+            JobStatus result;
+            switch (status)
+            {
+                case directsignaturejobstatus.SIGNED:
+                    result = JobStatus.Signed;
+                    break;
+                case directsignaturejobstatus.REJECTED:
+                    result = JobStatus.Rejected;
+                    break;
+                case directsignaturejobstatus.FAILED:
+                    result = JobStatus.Failed;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(status), status, null);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
@@ -311,13 +311,13 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                 {
                     new Signature
                     {
-                        SignatureStatus = (SignatureStatus) Enum.Parse(typeof (SignatureStatus), signature1.status.ToString(), true),
+                        SignatureStatus = signature1.status.ToSignatureStatus(),
                         Signer = new Signer(signature1.personalidentificationnumber),
                         XadesReference = new XadesReference(new Uri(signature1.xadesurl))
                     },
                     new Signature
                     {
-                        SignatureStatus = (SignatureStatus) Enum.Parse(typeof (SignatureStatus), signature2.status.ToString(), true),
+                        SignatureStatus = signature2.status.ToSignatureStatus(),
                         Signer = new Signer(signature2.personalidentificationnumber),
                         XadesReference = new XadesReference(new Uri(signature2.xadesurl))
                     }

--- a/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
@@ -116,7 +116,7 @@ namespace Digipost.Signature.Api.Client.Portal.DataTransferObjects
         {
             var result = new Signature
             {
-                SignatureStatus = (SignatureStatus) Enum.Parse(typeof (SignatureStatus), signature.status.ToString(), true),
+                SignatureStatus = signature.status.ToSignatureStatus(),
                 Signer = new Signer(signature.personalidentificationnumber)
             };
 

--- a/Digipost.Signature.Api.Client.Portal/Enums/SignatureStatus.cs
+++ b/Digipost.Signature.Api.Client.Portal/Enums/SignatureStatus.cs
@@ -5,6 +5,7 @@
         Waiting,
         Rejected,
         Cancelled,
-        Signed
+        Signed,
+        Expired
     }
 }

--- a/Digipost.Signature.Api.Client.Portal/Extensions/EnumExtensions.cs
+++ b/Digipost.Signature.Api.Client.Portal/Extensions/EnumExtensions.cs
@@ -17,7 +17,35 @@ namespace Digipost.Signature.Api.Client.Portal.Extensions
                     result = JobStatus.Completed;
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException("Could not parse status.");
+                    throw new ArgumentOutOfRangeException(nameof(status), status, null);
+            }
+
+            return result;
+        }
+
+        public static SignatureStatus ToSignatureStatus(this signaturestatus status)
+        {
+            SignatureStatus result;
+
+            switch (status)
+            {
+                case signaturestatus.WAITING:
+                    result = SignatureStatus.Waiting;
+                    break;
+                case signaturestatus.REJECTED:
+                    result = SignatureStatus.Rejected;
+                    break;
+                case signaturestatus.CANCELLED:
+                    result = SignatureStatus.Cancelled;
+                    break;
+                case signaturestatus.EXPIRED:
+                    result = SignatureStatus.Expired;
+                    break;
+                case signaturestatus.SIGNED:
+                    result = SignatureStatus.Signed;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(status), status, null);
             }
 
             return result;


### PR DESCRIPTION
There was no explicit compile time checking for enum conversion, giving outdated enums. This is now implemented via extensions for all enums.