### PR TITLE
Adds fix to validate all Xml in/out

### DIFF
--- a/Digipost.Signature.Api.Client.Core.Tests/Fakes/FakeHttpClientHandlerForGetStatusResponse .cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/Fakes/FakeHttpClientHandlerForGetStatusResponse .cs
@@ -4,7 +4,7 @@ using Digipost.Signature.Api.Client.Core.Tests.Utilities;
 
 namespace Digipost.Signature.Api.Client.Direct.Tests.Fakes
 {
-    internal class FakeHttpClientHandlerGetStatusResponse : FakeHttpClientHandlerResponse
+    internal class FakeHttpClientHandlerForStatusResponse : FakeHttpClientHandlerResponse
     {
         public override HttpContent GetContent()
         {

--- a/Digipost.Signature.Api.Client.Core.Tests/Fakes/FakeHttpClientHandlerForGetStatusResponseInvalid.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/Fakes/FakeHttpClientHandlerForGetStatusResponseInvalid.cs
@@ -1,14 +1,14 @@
 ﻿using System.Net.Http;
-using Digipost.Signature.Api.Client.Core.Tests.Fakes;
+using System.Text;
 using Digipost.Signature.Api.Client.Core.Tests.Utilities;
 
-namespace Digipost.Signature.Api.Client.Direct.Tests.Fakes
+namespace Digipost.Signature.Api.Client.Core.Tests.Fakes
 {
-    internal class FakeHttpClientHandlerGetStatusResponseInvalid : FakeHttpClientHandlerResponse
+    internal class FakeHttpClientHandlerForStatusResponseInvalid : FakeHttpClientHandlerResponse
     {
         public override HttpContent GetContent()
         {
-            return new StringContent(ContentUtility.GetStatusResponseInvalid());
+            return new StringContent(ContentUtility.GetStatusResponseInvalid(), Encoding.UTF8, "application/xml");
         }
     }
 }

--- a/Digipost.Signature.Api.Client.Core.Tests/Fakes/FakeHttpClientHandlerForXadesResponse.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/Fakes/FakeHttpClientHandlerForXadesResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Net.Http.Headers;
 using Digipost.Signature.Api.Client.Core.Tests.Utilities;
 
 namespace Digipost.Signature.Api.Client.Core.Tests.Fakes
@@ -7,7 +8,9 @@ namespace Digipost.Signature.Api.Client.Core.Tests.Fakes
     {
         public override HttpContent GetContent()
         {
-            return new StreamContent(CoreResponseUtility.GetXades());
+            var streamContent = new StreamContent(CoreResponseUtility.GetXades());
+            streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/xml");
+            return streamContent;
         }
     }
 }

--- a/Digipost.Signature.Api.Client.Core.Tests/Internal/XsdRequestValidationHandlerTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/Internal/XsdRequestValidationHandlerTests.cs
@@ -5,7 +5,6 @@ using Digipost.Signature.Api.Client.Core.Exceptions;
 using Digipost.Signature.Api.Client.Core.Internal;
 using Digipost.Signature.Api.Client.Core.Tests.Fakes;
 using Digipost.Signature.Api.Client.Core.Tests.Utilities;
-using Digipost.Signature.Api.Client.Direct.Tests.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Digipost.Signature.Api.Client.Core.Tests.Internal
@@ -36,36 +35,24 @@ namespace Digipost.Signature.Api.Client.Core.Tests.Internal
         public class SendAsync : XsdRequestValidationHandlerTests
         {
             [TestMethod]
-            public async Task AcceptsValidXml()
+            public async Task AcceptsRequestWithXmlInMultipart()
             {
                 //Arrange
-                var client = GetClientWithRequestValidator(new FakeHttpClientHandlerForDirectCreateResponse());
-                var invalidRequestContent = new FakeHttpClientHandlerForMultipartXml(ContentUtility.GetDirectSignatureJobRequestBody()).GetContent();
+                var client = GetClientWithRequestValidator(new FakeHttpClientForDataResponse());
+                var validRequestContent = new FakeHttpClientHandlerForMultipartXml(ContentUtility.GetDirectSignatureJobRequestBody()).GetContent();
 
                 //Act
-                await client.SendAsync(GetHttpRequestMessage(invalidRequestContent));
-
-                //Assert
-            }
-
-            [TestMethod]
-            public async Task AcceptsGetRequest()
-            {
-                //Arrange
-                var client = GetClientWithRequestValidator(new FakeHttpClientHandlerGetStatusResponse());
-
-                //Act
-                await client.GetAsync("http://bogusurl.no");
+                await client.SendAsync(GetHttpRequestMessage(validRequestContent));
 
                 //Assert
             }
 
             [TestMethod]
             [ExpectedException(typeof (InvalidXmlException))]
-            public async Task ThrowsExceptionOnInvalidXml()
+            public async Task ThrowsExceptionOnRequestWithInvalidXmlInMultipart()
             {
                 //Arrange
-                var client = GetClientWithRequestValidator(new FakeHttpClientHandlerForDirectCreateResponse());
+                var client = GetClientWithRequestValidator(new FakeHttpClientForDataResponse());
                 var invalidRequestContent = new FakeHttpClientHandlerForMultipartXml(ContentUtility.GetDirectSignatureJobRequestBodyInvalid()).GetContent();
 
                 //Act
@@ -73,6 +60,18 @@ namespace Digipost.Signature.Api.Client.Core.Tests.Internal
 
                 //Assert
                 Assert.Fail();
+            }
+
+            [TestMethod]
+            public async Task AcceptsRequestWithNoBody()
+            {
+                //Arrange
+                var client = GetClientWithRequestValidator(new FakeHttpClientForDataResponse());
+
+                //Act
+                await client.GetAsync("http://bogusurl.no");
+
+                //Assert
             }
         }
     }

--- a/Digipost.Signature.Api.Client.Core/Internal/XsdRequestValidationHandler.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/XsdRequestValidationHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -6,11 +7,28 @@ namespace Digipost.Signature.Api.Client.Core.Internal
 {
     internal class XsdRequestValidationHandler : XsdValidationHandler
     {
+        private const string MultipartMixed = "multipart/mixed";
+
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             await ValidateXmlAndThrowIfInvalid(request.Content, cancellationToken);
 
             return await base.SendAsync(request, cancellationToken);
+        }
+
+        private async Task ValidateXmlAndThrowIfInvalid(HttpContent content, CancellationToken cancellationToken)
+        {
+            var contentMediaType = content?.Headers.ContentType?.MediaType;
+
+            if (contentMediaType == MultipartMixed)
+            {
+                var multipart = await content.ReadAsMultipartAsync(cancellationToken);
+
+                foreach (var httpContent in multipart.Contents.Where(httpContent => httpContent.Headers.ContentType.MediaType == ApplicationXml))
+                {
+                    ValidateXml(await httpContent.ReadAsStringAsync());
+                }
+            }
         }
     }
 }

--- a/Digipost.Signature.Api.Client.Core/Internal/XsdResponseValidationHandler.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/XsdResponseValidationHandler.cs
@@ -10,9 +10,24 @@ namespace Digipost.Signature.Api.Client.Core.Internal
         {
             var result = await base.SendAsync(request, cancellationToken);
 
-            await ValidateXmlAndThrowIfInvalid(result.Content, cancellationToken);
+            var mustValidateForCurrentEndpoint = !request.RequestUri.AbsolutePath.ToLower().Contains("xades");
+            if (mustValidateForCurrentEndpoint)
+            {
+                await ValidateXmlAndThrowIfInvalid(result.Content);
+            }
 
             return result;
+        }
+
+        private async Task ValidateXmlAndThrowIfInvalid(HttpContent content)
+        {
+            var contentMediaType = content?.Headers.ContentType?.MediaType;
+
+            if (contentMediaType == ApplicationXml)
+            {
+                var readAsStringAsync = await content.ReadAsStringAsync();
+                ValidateXml(readAsStringAsync);
+            }
         }
     }
 }

--- a/Digipost.Signature.Api.Client.Core/Internal/XsdValidationHandler.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/XsdValidationHandler.cs
@@ -1,7 +1,4 @@
-using System.Linq;
 using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Digipost.Signature.Api.Client.Core.Exceptions;
 using Digipost.Signature.Api.Client.Core.Xsd;
 
@@ -9,21 +6,13 @@ namespace Digipost.Signature.Api.Client.Core.Internal
 {
     public class XsdValidationHandler : DelegatingHandler
     {
-        protected static async Task ValidateXmlAndThrowIfInvalid(HttpContent content, CancellationToken cancellationToken)
-        {
-            if (content?.Headers.ContentType?.MediaType == "multipart/mixed")
-            {
-                var multipart = await content.ReadAsMultipartAsync(cancellationToken);
-                var requestBody = await multipart.Contents.ElementAt(0).ReadAsStringAsync();
-                ValidateXmlBody(requestBody);
-            }
-        }
+        protected const string ApplicationXml = "application/xml";
 
-        private static void ValidateXmlBody(string body)
+        protected static void ValidateXml(string xml)
         {
             var xsdValidator = new XsdValidator();
+            xsdValidator.ValiderDokumentMotXsd(xml);
 
-            xsdValidator.ValiderDokumentMotXsd(body);
             if (!string.IsNullOrEmpty(xsdValidator.ValideringsVarsler))
             {
                 throw new InvalidXmlException(xsdValidator.ValideringsVarsler);

--- a/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
@@ -129,7 +129,7 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.Smoke
                 var portalClient = GetPortalClient();
 
                 //Act
-                portalClient.GetPades(_padesReference);
+                await portalClient.GetPades(_padesReference);
                 //await WritePadesToFile(portalClient, padesReference);
 
                 //Assert


### PR DESCRIPTION
We now correctly parse response and request with Xml-content. More tests has been added to ensure that we do not parse Xades.