### PR TITLE
Made it possible to retrive the base statusurl 

### DIFF
--- a/Digipost.Signature.Api.Client.Direct/ResponseUrls.cs
+++ b/Digipost.Signature.Api.Client.Direct/ResponseUrls.cs
@@ -4,11 +4,11 @@ namespace Digipost.Signature.Api.Client.Direct
 {
     public class ResponseUrls
     {
-        private readonly Uri _statusUrl;
+        public readonly Uri StatusBaseUrl;
 
-        public ResponseUrls(Uri redirectUrl, Uri statusUrl)
+        public ResponseUrls(Uri redirectUrl, Uri statusBaseUrl)
         {
-            _statusUrl = statusUrl;
+            StatusBaseUrl = statusBaseUrl;
             Redirect = new RedirectReference(redirectUrl);
         }
 
@@ -27,7 +27,7 @@ namespace Digipost.Signature.Api.Client.Direct
         /// <returns></returns>
         public StatusReference Status(string statusQueryToken)
         {
-            return new StatusReference(_statusUrl, statusQueryToken);
+            return new StatusReference(StatusBaseUrl, statusQueryToken);
         }
     }
 }

--- a/Digipost.Signature.Api.Client.Direct/ResponseUrls.cs
+++ b/Digipost.Signature.Api.Client.Direct/ResponseUrls.cs
@@ -4,8 +4,6 @@ namespace Digipost.Signature.Api.Client.Direct
 {
     public class ResponseUrls
     {
-        public readonly Uri StatusBaseUrl;
-
         public ResponseUrls(Uri redirectUrl, Uri statusBaseUrl)
         {
             StatusBaseUrl = statusBaseUrl;
@@ -13,6 +11,8 @@ namespace Digipost.Signature.Api.Client.Direct
         }
 
         public RedirectReference Redirect { get; set; }
+
+        public Uri StatusBaseUrl { get; private set; }
 
         /// <summary>
         ///     A <see cref="StatusReference" /> is constructed from the url acquired from


### PR DESCRIPTION
Exposing the BaseStatusUrl enables the following at a later time:
```c#
new StatusReference(new Uri(Data.StatusUrl), message.CollectToken));
```

Today the base-statusurl is a private field