### PR TITLE
Legger til 1.7 docs

### DIFF
--- a/Digipost.Signature.Api.Client.Core.Tests/Smoke/SmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/Smoke/SmokeTests.cs
@@ -58,7 +58,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests.Smoke
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-
+            
             return result;
         }
 

--- a/Digipost.Signature.Api.Client.Core/packages.config
+++ b/Digipost.Signature.Api.Client.Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="api-client-shared" version="1.2.0" targetFramework="net45" />
+  <package id="api-client-shared" version="2.0.0" targetFramework="net45" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
-  <package id="difi-felles-utility-dotnet" version="0.9.0" targetFramework="net45" />
+  <package id="difi-felles-utility-dotnet" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>

--- a/Digipost.Signature.Api.Client.TestClient/Program.cs
+++ b/Digipost.Signature.Api.Client.TestClient/Program.cs
@@ -19,7 +19,7 @@ namespace Digipost.Signature.Api.Client.TestClient
             Log.Warn("Warn logging");
             Log.Error("Error logging");
             Log.Fatal("Fatal logging");
-            var client = new PortalClient(new ClientConfiguration(Environment.DifiQa, "2d 7f 30 dd 05 d3 b7 fc 7a e5 97 3a 73 f8 49 08 3b 20 40 ed", new Sender("123456789")));
+            var client = new PortalClient(new ClientConfiguration(Environment.DifiQa, "‎2d 7f 30 dd 05 d3 b7 fc 7a e5 97 3a 73 f8 49 08 3b 20 40 ed", new Sender("123456789")));
 
             Console.WriteLine("Finished with loggah ...");
             Console.ReadLine();

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,8 +10,8 @@ licenseUrl: http://opensource.org/licenses/MIT
 
 baseurl: "/signature-api-client-dotnet"
 
-currentVersion: "1.6"
-versions: ["1.6", "1.5", "1.4"]
+currentVersion: "1.7"
+versions: ["1.7", "1.6", "1.5", "1.4"]
 
 collections:
   v1_4:
@@ -23,6 +23,9 @@ collections:
   v1_6:
     output: true
     permalink: /v1.6/
+  v1_7:
+    output: true
+    permalink: /v1.7/
 
 # list of additional links on the right of the top menu
 headerLinks:

--- a/docs/_v1_7/1_setup.md
+++ b/docs/_v1_7/1_setup.md
@@ -27,12 +27,12 @@ To communicate over HTTPS you need to sign your request with a business certific
 1.  Select _Automatically select the certificate store based on the type of certificate_
 1.  Click _Next_ and _Finish_
 1.  Accept the certificate if prompted.
-1.  When prompted that the import was successful, click _Ok_.
+1.  When prompted that the import was successful, click _Ok_
 
 ### Use business certificate thumbprint
 
 1. Start mmc.exe (Click windowsbutton and type mmc.exe)
-1. _Choose File_ -> _Add/Remove Snap-in…_(Ctrl + M)
+1. _Choose File_ -> _Add/Remove Snap-in…_ (Ctrl + M)
 1. Mark certificate and click _Add >_
 1. If the certificate was installed in _Current User_ choose _My User Account_ and if installed on _Local Machine_ choose _Computer Account_. Then click _Finish_ and then _OK_
 1. Expand _Certificates_ node, select _Personal_ and open _Certificates_

--- a/docs/_v1_7/1_setup.md
+++ b/docs/_v1_7/1_setup.md
@@ -1,0 +1,42 @@
+---
+identifier: setup
+title: Initial setup
+layout: default
+---
+
+The client library is available as a nuget package. The client library (and associated nuget package) is updated regularly as new functionality is added. 
+
+
+To install the nuget package, follow these steps in Visual Studio:
+
+1. Select _TOOLS -> nuget Package Manager -> Manage nuget Packages Solution..._
+2. Search for _digipost-signature-api-client-dotnet_.
+* If you would like pre-releases of this package, make sure _Include Prerelease_ is enabled. Please refer to documentation for your version of Visual Studio for detailed instructions.
+3. Select _digipost-signature-api-client_ and click _Install_.
+
+<h3 id="businesscertificate">Install business certificate in certificate store</h3>
+
+<blockquote>SSL Certificates are small data files that digitally bind a cryptographic key to an organization's details. When installed on a web server, it activates the padlock and the https protocol (over port 443) and allows secure connections from a web server to a browser.</blockquote>
+
+To communicate over HTTPS you need to sign your request with a business certificate. The following steps will install the certificate in the your certificate store. This should be done on the server where your application will run.
+
+1.  Double-click on the actual certificate file (CertificateName.p12)
+2.  Save the sertificate in _Current User_ or _Local Machine_and click _Next_ 
+3.  USe the suggested filename. Click _Next_
+4.  Enter password for private key and select _Mark this key as exportable ..._ Click _Next_
+5.  Select _Automatically select the certificate store based on the type of certificate_
+6.  Click _Next_ and _Finish_
+7.  Accept the certificate if prompted.
+8.  When prompted that the import was successful, click _Ok_.
+
+<h3 id="find_businesscertificate">Use business certificate thumbprint</h3>
+
+1. Start mmc.exe (Click windowsbutton and type mmc.exe)
+2. _Choose File_ -> _Add/Remove Snap-in…_(Ctrl + M)
+3. Mark certificate and click _Add >_
+4. If the certificate was installed in _Current User_ choose _My User Account_ and if installed on _Local Machine_ choose _Computer Account_. Then click _Finish_ and then _OK_.
+5. Expand _Certificates_ node, select _Personal_ and open _Certificates_
+6. Double-click on the installed certificate
+7. Go to the _Details_ tab
+8. Scroll down to _Thumbprint_
+9. Copy the thumbprint.

--- a/docs/_v1_7/1_setup.md
+++ b/docs/_v1_7/1_setup.md
@@ -10,33 +10,33 @@ The client library is available as a nuget package. The client library (and asso
 To install the nuget package, follow these steps in Visual Studio:
 
 1. Select _TOOLS -> nuget Package Manager -> Manage nuget Packages Solution..._
-2. Search for _digipost-signature-api-client-dotnet_.
+1. Search for _digipost-signature-api-client-dotnet_.
 * If you would like pre-releases of this package, make sure _Include Prerelease_ is enabled. Please refer to documentation for your version of Visual Studio for detailed instructions.
-3. Select _digipost-signature-api-client_ and click _Install_.
+1. Select _digipost-signature-api-client_ and click _Install_.
 
-<h3 id="businesscertificate">Install business certificate in certificate store</h3>
+### Install business certificate in certificate store
 
 <blockquote>SSL Certificates are small data files that digitally bind a cryptographic key to an organization's details. When installed on a web server, it activates the padlock and the https protocol (over port 443) and allows secure connections from a web server to a browser.</blockquote>
 
 To communicate over HTTPS you need to sign your request with a business certificate. The following steps will install the certificate in the your certificate store. This should be done on the server where your application will run.
 
 1.  Double-click on the actual certificate file (CertificateName.p12)
-2.  Save the sertificate in _Current User_ or _Local Machine_and click _Next_ 
-3.  USe the suggested filename. Click _Next_
-4.  Enter password for private key and select _Mark this key as exportable ..._ Click _Next_
-5.  Select _Automatically select the certificate store based on the type of certificate_
-6.  Click _Next_ and _Finish_
-7.  Accept the certificate if prompted.
-8.  When prompted that the import was successful, click _Ok_.
+1.  Save the sertificate in _Current User_ or _Local Machine_ and click _Next_ 
+1.  USe the suggested filename. Click _Next_
+1.  Enter password for private key and select _Mark this key as exportable ..._ Click _Next_
+1.  Select _Automatically select the certificate store based on the type of certificate_
+1.  Click _Next_ and _Finish_
+1.  Accept the certificate if prompted.
+1.  When prompted that the import was successful, click _Ok_.
 
-<h3 id="find_businesscertificate">Use business certificate thumbprint</h3>
+### Use business certificate thumbprint
 
 1. Start mmc.exe (Click windowsbutton and type mmc.exe)
-2. _Choose File_ -> _Add/Remove Snap-in…_(Ctrl + M)
-3. Mark certificate and click _Add >_
-4. If the certificate was installed in _Current User_ choose _My User Account_ and if installed on _Local Machine_ choose _Computer Account_. Then click _Finish_ and then _OK_.
-5. Expand _Certificates_ node, select _Personal_ and open _Certificates_
-6. Double-click on the installed certificate
-7. Go to the _Details_ tab
-8. Scroll down to _Thumbprint_
-9. Copy the thumbprint.
+1. _Choose File_ -> _Add/Remove Snap-in…_(Ctrl + M)
+1. Mark certificate and click _Add >_
+1. If the certificate was installed in _Current User_ choose _My User Account_ and if installed on _Local Machine_ choose _Computer Account_. Then click _Finish_ and then _OK_
+1. Expand _Certificates_ node, select _Personal_ and open _Certificates_
+1. Double-click on the installed certificate
+1. Go to the _Details_ tab
+1. Scroll down to _Thumbprint_
+1. Copy the thumbprint

--- a/docs/_v1_7/2_direct_usecases.md
+++ b/docs/_v1_7/2_direct_usecases.md
@@ -1,0 +1,158 @@
+---
+identifier: directusecases
+title: Direct use cases
+layout: default
+---
+
+<h3 id="uc01">Create Client Configuration</h3>
+
+{% highlight csharp %}
+
+const string organizationNumber = "123456789";
+const string certificateThumbprint = "3k 7f 30 dd 05 d3 b7 fc...";
+
+var clientConfiguration = new ClientConfiguration(
+    Environment.DifiQa,
+    certificateThumbprint,
+    new Sender(organizationNumber));
+
+{% endhighlight %}
+
+<blockquote>
+Note: If the sender changes per signature job created, the sender can be set on the job itself. The sender of the job will always take precedence over the sender in <code>ClientConfiguration</code>. This means that a default sender can be set in <code>ClientConfiguration</code> and, when required, on a specific job.   
+</blockquote>
+
+<h3 id="uc02">Create signature job</h3>
+
+{% highlight csharp %}
+
+ClientConfiguration clientConfiguration = null; //As initialized earlier
+var directClient = new DirectClient(clientConfiguration);
+
+var documentToSign = new Document(
+    "Subject of Message", 
+    "This is the content", 
+    FileType.Pdf, 
+    @"C:\Path\ToDocument\File.pdf");
+
+var exitUrls = new ExitUrls(
+    new Uri("http://redirectUrl.no/onCompletion"), 
+    new Uri("http://redirectUrl.no/onCancellation"), 
+    new Uri("http://redirectUrl.no/onError")
+    );
+
+var signers = new List<Signer>
+{
+    new Signer(new PersonalIdentificationNumber("12345678910")),
+    new Signer(new PersonalIdentificationNumber("10987654321"))
+};
+
+var job = new Job(documentToSign, signers, "SendersReferenceToSignatureJob", exitUrls);
+
+var directJobResponse = await directClient.Create(job);
+
+{% endhighlight %}
+
+<h3 id="uc03">Get direct job status</h3>
+
+The signing process is a synchrounous operation in the direct use case. There is no need to poll for changes to a signature job, as the status is well known to the sender of the job. As soon as the signer cancels, completes or an error occurs, the user is redirected to the respective Urls set in `ExitUrls`. A `status_query_token` parameter has been added to the url. Use this when requesting a status change.
+
+{% highlight csharp %}
+
+ClientConfiguration clientConfiguration = null; //As initialized earlier
+var directClient = new DirectClient(clientConfiguration);
+JobResponse jobResponse = null; //As initialized when creating signature job
+var statusQueryToken = "0A3BQ54C...";
+
+var jobStatusResponse =
+    await directClient.GetStatus(jobResponse.ResponseUrls.Status(statusQueryToken));
+
+var jobStatus = jobStatusResponse.Status;
+
+{% endhighlight %}
+
+<h3 id="uc04">Get direct job status by polling</h3>
+
+If you, for any reason, are unable to retrieve status by using the status query token specified <a href="#uc03">above</a>, you may poll the service for any changes done to your organization's jobs. If the queue is empty, additional polling will give an exception.
+
+<blockquote>Note: For the job to be available in the polling queue, make sure to specify the job's <code>statusRetrievalMethod</code> as illustrated below.</blockquote>
+
+{% highlight csharp %}
+
+ClientConfiguration clientConfiguration = null; // As initialized earlier
+var directClient = new DirectClient(clientConfiguration);
+
+Document documentToSign = null; // As initialized earlier
+ExitUrls exitUrls = null; // As initialized earlier
+
+var signer = new PersonalIdentificationNumber("12345678910");
+
+var job = new Job(
+    documentToSign,
+    new List<Signer> {new Signer(signer)},
+    "SendersReferenceToSignatureJob",
+    exitUrls,
+    statusRetrievalMethod: StatusRetrievalMethod.Polling
+    );
+
+await directClient.Create(job);
+
+var changedJob = await directClient.GetStatusChange();
+
+if (changedJob.Status == JobStatus.NoChanges)
+{
+    // Queue is empty. Additional polling will result in blocking for a defined period.
+}
+
+// Repeat the above until signer signs the document
+
+changedJob = await directClient.GetStatusChange();
+
+if (changedJob.Status == JobStatus.CompletedSuccessfully)
+{
+    // Get PAdES
+}
+
+if (changedJob.GetSignatureFrom(signer).SignatureStatus.Equals(SignatureStatus.Signed))
+{
+    // Get XAdES
+}
+
+// Confirm status change to avoid receiving it again
+await directClient.Confirm(changedJob.References.Confirmation);
+
+{% endhighlight %}
+
+<h3 id="uc05">Get Xades And Pades</h3>
+
+{% highlight csharp %}
+
+ClientConfiguration clientConfiguration = null; //As initialized earlier
+var directClient = new DirectClient(clientConfiguration);
+JobStatusResponse jobStatusResponse = null; // Result of requesting job status
+
+if (jobStatusResponse.Status == JobStatus.CompletedSuccessfully)
+{
+    var padesByteStream = await directClient.GetPades(jobStatusResponse.References.Pades);
+}
+
+var signature = jobStatusResponse.GetSignatureFrom(new PersonalIdentificationNumber("12345678910"));
+
+if (signature.Equals(SignatureStatus.Signed))
+{
+    var xadesByteStream = await directClient.GetXades(signature.XadesReference);
+}
+
+{% endhighlight %}
+
+<h3 id="uc06">Confirm received signature job</h3>
+
+{% highlight csharp %}
+
+ClientConfiguration clientConfiguration = null; //As initialized earlier
+var directClient = new DirectClient(clientConfiguration);
+JobStatusResponse jobStatusResponse = null; // Result of requesting job status
+
+await directClient.Confirm(jobStatusResponse.References.Confirmation);
+
+{% endhighlight %}

--- a/docs/_v1_7/2_direct_usecases.md
+++ b/docs/_v1_7/2_direct_usecases.md
@@ -12,7 +12,7 @@ const string organizationNumber = "123456789";
 const string certificateThumbprint = "3k 7f 30 dd 05 d3 b7 fc...";
 
 var clientConfiguration = new ClientConfiguration(
-    Environment.DifiQa,
+    Environment.DifiTest,
     certificateThumbprint,
     new Sender(organizationNumber));
 

--- a/docs/_v1_7/2_direct_usecases.md
+++ b/docs/_v1_7/2_direct_usecases.md
@@ -4,7 +4,7 @@ title: Direct use cases
 layout: default
 ---
 
-<h3 id="uc01">Create Client Configuration</h3>
+### Create Client Configuration
 
 {% highlight csharp %}
 
@@ -22,7 +22,7 @@ var clientConfiguration = new ClientConfiguration(
 Note: If the sender changes per signature job created, the sender can be set on the job itself. The sender of the job will always take precedence over the sender in <code>ClientConfiguration</code>. This means that a default sender can be set in <code>ClientConfiguration</code> and, when required, on a specific job.   
 </blockquote>
 
-<h3 id="uc02">Create signature job</h3>
+### Create signature job
 
 {% highlight csharp %}
 
@@ -53,7 +53,7 @@ var directJobResponse = await directClient.Create(job);
 
 {% endhighlight %}
 
-<h3 id="uc03">Get direct job status</h3>
+### Get direct job status
 
 The signing process is a synchrounous operation in the direct use case. There is no need to poll for changes to a signature job, as the status is well known to the sender of the job. As soon as the signer cancels, completes or an error occurs, the user is redirected to the respective Urls set in `ExitUrls`. A `status_query_token` parameter has been added to the url. Use this when requesting a status change.
 
@@ -71,7 +71,7 @@ var jobStatus = jobStatusResponse.Status;
 
 {% endhighlight %}
 
-<h3 id="uc04">Get direct job status by polling</h3>
+### Get direct job status by polling
 
 If you, for any reason, are unable to retrieve status by using the status query token specified <a href="#uc03">above</a>, you may poll the service for any changes done to your organization's jobs. If the queue is empty, additional polling will give an exception.
 
@@ -123,7 +123,7 @@ await directClient.Confirm(changedJob.References.Confirmation);
 
 {% endhighlight %}
 
-<h3 id="uc05">Get Xades And Pades</h3>
+### Get Xades And Pades
 
 {% highlight csharp %}
 
@@ -145,7 +145,7 @@ if (signature.Equals(SignatureStatus.Signed))
 
 {% endhighlight %}
 
-<h3 id="uc06">Confirm received signature job</h3>
+Confirm received signature job
 
 {% highlight csharp %}
 

--- a/docs/_v1_7/2_direct_usecases.md
+++ b/docs/_v1_7/2_direct_usecases.md
@@ -145,7 +145,7 @@ if (signature.Equals(SignatureStatus.Signed))
 
 {% endhighlight %}
 
-Confirm received signature job
+### Confirm received signature job
 
 {% highlight csharp %}
 

--- a/docs/_v1_7/3_portal_usecases.md
+++ b/docs/_v1_7/3_portal_usecases.md
@@ -12,10 +12,9 @@ const string organizationNumber = "123456789";
 const string certificateThumbprint = "3k 7f 30 dd 05 d3 b7 fc...";
 
 var clientConfiguration = new ClientConfiguration(
-    Environment.DifiQa,
+    Environment.DifiTest,
     certificateThumbprint,
     new Sender(organizationNumber));
-
 {% endhighlight %}
 
 <blockquote>
@@ -31,17 +30,17 @@ The following example shows how to create a document and send it to two signers.
 PortalClient portalClient = null; //As initialized earlier
 
 var documentToSign = new Document(
-    "Subject of Message", 
-    "This is the content", 
-    FileType.Pdf, 
+    "Subject of Message",
+    "This is the content",
+    FileType.Pdf,
     @"C:\Path\ToDocument\File.pdf"
     );
 
 var signers = new List<Signer>
 {
-    new Signer(new PersonalIdentificationNumber("12345678910"), new NotificationsUsingLookup()),
-    new Signer(new PersonalIdentificationNumber("12345678911"), new Notifications(
-        new Email("overridden@mail.com"), 
+    new Signer(new PersonalIdentificationNumber("00000000000"), new NotificationsUsingLookup()),
+    new Signer(new PersonalIdentificationNumber("11111111111"), new Notifications(
+        new Email("test@example.com"),
         new Sms("999999999")))
 };
 

--- a/docs/_v1_7/3_portal_usecases.md
+++ b/docs/_v1_7/3_portal_usecases.md
@@ -4,7 +4,7 @@ title: Portal use cases
 layout: default
 ---
 
-<h3 id="uc07">Create Client Configuration</h3>
+### Create Client Configuration
 
 {% highlight csharp %}
 
@@ -21,7 +21,7 @@ var clientConfiguration = new ClientConfiguration(
 Note: If the sender changes per signature job created, the sender can be set on the job itself. The sender of the job will always take precedence over the sender in <code>ClientConfiguration</code>. This means that a default sender can be set in <code>ClientConfiguration</code> and, when required, on a specific job.   
 </blockquote>
 
-<h3 id="uc08">Create and send portal signature job</h3>
+### Create and send portal signature job
 
 The following example shows how to create a document and send it to two signers.
 
@@ -51,8 +51,9 @@ var portalJobResponse = await portalClient.Create(portalJob);
 
 {% endhighlight %}
 
+> Note that only public organizations can do `NotificationsUsingLookup`.
 
-<h3 id="uc09">Get portal job status change</h3>
+### Get portal job status change
 
 All changes to signature jobs will be added to a queue. You can poll for these changes. If the queue is empty, then additional polling will give an exception. The following example shows how this can be handled and examples of data to extract from a change response.
 
@@ -86,7 +87,7 @@ catch (TooEagerPollingException eagerPollingException)
 
 {% endhighlight %}
 
-<h3 id="uc10">Get Xades and Pades</h3>
+### Get Xades and Pades
 
 When getting Xades and Pades for a `PortalJob`, remember that the Xades is per signer, while there is only one Pades. 
 
@@ -103,7 +104,7 @@ var pades = await portalClient.GetPades(jobStatusChanged.PadesReference);
 
 {% endhighlight %}
 
-<h3 id="uc11">Confirm portal job</h3>
+### Confirm portal job
 
 {% highlight csharp %}
 

--- a/docs/_v1_7/3_portal_usecases.md
+++ b/docs/_v1_7/3_portal_usecases.md
@@ -87,19 +87,19 @@ catch (TooEagerPollingException eagerPollingException)
 
 {% endhighlight %}
 
-### Get Xades and Pades
+### Get XAdES and PAdES
 
-When getting Xades and Pades for a `PortalJob`, remember that the Xades is per signer, while there is only one Pades. 
+When getting XAdES and PAdES for a `PortalJob`, remember that the XAdES is per signer, while there is only one PAdES. 
 
 {% highlight csharp %}
 
 PortalClient portalClient = null; //As initialized earlier
 var jobStatusChanged = await portalClient.GetStatusChange();
 
-//Get Xades:
+//Get XAdES:
 var xades = await portalClient.GetXades(jobStatusChanged.Signatures.ElementAt(0).XadesReference);
 
-//Get Pades:
+//Get PAdES:
 var pades = await portalClient.GetPades(jobStatusChanged.PadesReference);
 
 {% endhighlight %}

--- a/docs/_v1_7/3_portal_usecases.md
+++ b/docs/_v1_7/3_portal_usecases.md
@@ -1,0 +1,116 @@
+---
+identifier: portalusecases
+title: Portal use cases
+layout: default
+---
+
+<h3 id="uc07">Create Client Configuration</h3>
+
+{% highlight csharp %}
+
+const string organizationNumber = "123456789";
+const string certificateThumbprint = "3k 7f 30 dd 05 d3 b7 fc...";
+
+var clientConfiguration = new ClientConfiguration(
+    Environment.DifiQa,
+    certificateThumbprint,
+    new Sender(organizationNumber));
+
+{% endhighlight %}
+
+<blockquote>
+Note: If the sender changes per signature job created, the sender can be set on the job itself. The sender of the job will always take precedence over the sender in <code>ClientConfiguration</code>. This means that a default sender can be set in <code>ClientConfiguration</code> and, when required, on a specific job.   
+</blockquote>
+
+<h3 id="uc08">Create and send portal signature job</h3>
+
+The following example shows how to create a document and send it to two signers.
+
+{% highlight csharp %}
+
+PortalClient portalClient = null; //As initialized earlier
+
+var documentToSign = new Document(
+    "Subject of Message", 
+    "This is the content", 
+    FileType.Pdf, 
+    @"C:\Path\ToDocument\File.pdf"
+    );
+
+var signers = new List<Signer>
+{
+    new Signer(new PersonalIdentificationNumber("12345678910"), new NotificationsUsingLookup()),
+    new Signer(new PersonalIdentificationNumber("12345678911"), new Notifications(
+        new Email("overridden@mail.com"), 
+        new Sms("999999999")))
+};
+
+var portalJob = new Job(documentToSign, signers, "myReferenceToJob");
+
+var portalJobResponse = await portalClient.Create(portalJob);
+
+
+{% endhighlight %}
+
+
+<h3 id="uc09">Get portal job status change</h3>
+
+All changes to signature jobs will be added to a queue. You can poll for these changes. If the queue is empty, then additional polling will give an exception. The following example shows how this can be handled and examples of data to extract from a change response.
+
+{% highlight csharp %}
+
+PortalClient portalClient = null; //As initialized earlier
+
+var jobStatusChanged = await portalClient.GetStatusChange();
+
+if (jobStatusChanged.Status == JobStatus.NoChanges)
+{
+    //Queue is empty. Additional polling will result in blocking for a defined period.
+}
+else
+{
+    var signatureJobStatus = jobStatusChanged.Status;
+    var signatures = jobStatusChanged.Signatures;
+    var signatureOne = signatures.ElementAt(0);
+    var signatureOneStatus = signatureOne.SignatureStatus;
+}
+
+//Polling again:
+try
+{
+    var changeResponse2 = await portalClient.GetStatusChange();
+}
+catch (TooEagerPollingException eagerPollingException)
+{
+    var nextAvailablePollingTime = eagerPollingException.NextPermittedPollTime;
+}
+
+{% endhighlight %}
+
+<h3 id="uc10">Get Xades and Pades</h3>
+
+When getting Xades and Pades for a `PortalJob`, remember that the Xades is per signer, while there is only one Pades. 
+
+{% highlight csharp %}
+
+PortalClient portalClient = null; //As initialized earlier
+var jobStatusChanged = await portalClient.GetStatusChange();
+
+//Get Xades:
+var xades = await portalClient.GetXades(jobStatusChanged.Signatures.ElementAt(0).XadesReference);
+
+//Get Pades:
+var pades = await portalClient.GetPades(jobStatusChanged.PadesReference);
+
+{% endhighlight %}
+
+<h3 id="uc11">Confirm portal job</h3>
+
+{% highlight csharp %}
+
+PortalClient portalClient = null; //As initialized earlier
+var jobStatusChangeResponse = await portalClient.GetStatusChange();
+
+await portalClient.Confirm(jobStatusChangeResponse.ConfirmationReference);
+
+{% endhighlight %}

--- a/docs/_v1_7/4_Error_Handling.md
+++ b/docs/_v1_7/4_Error_Handling.md
@@ -4,7 +4,7 @@ title: Error Handling
 layout: default
 ---
 
-<h3 id="errorHandlerHeader">Handling error</h3>
+### Handling error
 
 There are differet forms of exceptions that can occur. Some are more specific than others. All exceptions related to client behavior inherits from `SignatureException`. 
 

--- a/docs/_v1_7/4_Error_Handling.md
+++ b/docs/_v1_7/4_Error_Handling.md
@@ -1,0 +1,38 @@
+---
+identifier: errorhandling
+title: Error Handling
+layout: default
+---
+
+<h3 id="errorHandlerHeader">Handling error</h3>
+
+There are differet forms of exceptions that can occur. Some are more specific than others. All exceptions related to client behavior inherits from `SignatureException`. 
+
+{% highlight csharp %}
+
+try
+{
+    //Some signature action
+}
+catch (BrokerNotAuthorizedException notAuthorizedException)
+{
+    //Not authorized to perform action. The correct access rights for organization are not set.
+}
+catch (UnexpectedResponseException unexpectedResponseException)
+{
+    //UnexpectedResponseException will normally contain an `Error` object giving a more detailed error description. If this error does not exist, 
+    // you can still get the status code and message.
+    var statusCode = unexpectedResponseException.StatusCode;
+    var responseMessage = unexpectedResponseException.Message;
+
+    if (unexpectedResponseException.Error != null)
+    {
+        var errorMessage = unexpectedResponseException.Error.Message;
+        var errorType = unexpectedResponseException.Error.Type;
+    }
+}
+catch (SignatureException exception)
+{
+   
+}
+{% endhighlight %}

--- a/docs/_v1_7/5_Logging.md
+++ b/docs/_v1_7/5_Logging.md
@@ -5,7 +5,7 @@ layout: default
 ---
 
 
-<h3 id="loggingrequestflow">Logging request flow</h3>
+### Logging request flow
 The client is using Common Logging API for .NET as an abstraction for logging. It is up to the user to implement the API with a logging framework.
 
 <blockquote>Common Logging API is a lightweight infrastructure logging platform that allows developers to focus on the logging requirements instead of the logging tools and required configuration. The Common Logging API abstracts the logging requirements of any project making it easy to swap logging providers.</blockquote>
@@ -13,7 +13,7 @@ The client is using Common Logging API for .NET as an abstraction for logging. I
 
 Enabling logging on level `DEBUG` will output positive results of requests and worse, `WARN` only failed requests or worse, while `ERROR` will only occur on failed requests to create a signature job. These loggers will be under the `Digipost.Signature.Api.Client` namespace. 
 
-<h3 id="log4net">Implementing Log4Net</h3>
+### Implementing Log4Net
 1. Install Nuget-package `Common.Logging.Log4Net`. This will install the dependencies `Common.Logging.Core` and `Common.Logging`. Note that the versioning of Log4Net is a bit odd, but Nuget Gallery will reveal that Log4Net 2.0.3 has _Log4net [1.2.13] 2.0.3_ as package name. This means that `Common.Logging.Log4Net1213` is the correct logging adapter.
 2. In some cases the adapter may install the wrong version of Log4Net. If installing the adapter for 2.0.3, the version must be upped to this version too.
 
@@ -59,7 +59,7 @@ Complete App.config with the Log4Net adapter installed and a `RollingFileAppende
 
 {% endhighlight %}
 
-<h3 id="loggingrequestresponse">Logging request and response with Log4Net</h3>
+### Logging request and response with Log4Net
 
 For initial integration and debugging purposes, it can be useful to log the actual request and response going over the wire. This can be enabled by creating a logger with the name `Digipost.Signature.Api.Client.RequestLogger`. See the following example for how to log requests to trace and file:
 
@@ -98,7 +98,7 @@ For initial integration and debugging purposes, it can be useful to log the actu
 Warning: Enabling request logging should never be used in a production system. It will severely impact the performance of the client.	
 </blockquote>
 
-<h3 id="loggingdocumentbundle">Logging of document bundle</h3>
+### Logging of document bundle
 
 Logging of document bundle can be enabled via the `ClientConfiguration`:
 

--- a/docs/_v1_7/5_Logging.md
+++ b/docs/_v1_7/5_Logging.md
@@ -104,7 +104,7 @@ Logging of document bundle can be enabled via the `ClientConfiguration`:
 
 {% highlight csharp %}
 
-var clientConfiguration = new ClientConfiguration(Environment.DifiQa, "3k 7f 30 dd 05 d3 b7 fc...");
+var clientConfiguration = new ClientConfiguration(Environment.DifiTest, "3k 7f 30 dd 05 d3 b7 fc...");
 clientConfiguration.EnableDocumentBundleDiskDump("/directory/path/for/bundle/disk/dump");
 
 {% endhighlight %}

--- a/docs/_v1_7/5_Logging.md
+++ b/docs/_v1_7/5_Logging.md
@@ -1,0 +1,119 @@
+---
+identifier: Logging
+title: Logging
+layout: default
+---
+
+
+<h3 id="loggingrequestflow">Logging request flow</h3>
+The client is using Common Logging API for .NET as an abstraction for logging. It is up to the user to implement the API with a logging framework.
+
+<blockquote>Common Logging API is a lightweight infrastructure logging platform that allows developers to focus on the logging requirements instead of the logging tools and required configuration. The Common Logging API abstracts the logging requirements of any project making it easy to swap logging providers.</blockquote>
+
+
+Enabling logging on level `DEBUG` will output positive results of requests and worse, `WARN` only failed requests or worse, while `ERROR` will only occur on failed requests to create a signature job. These loggers will be under the `Digipost.Signature.Api.Client` namespace. 
+
+<h3 id="log4net">Implementing Log4Net</h3>
+1. Install Nuget-package `Common.Logging.Log4Net`. This will install the dependencies `Common.Logging.Core` and `Common.Logging`. Note that the versioning of Log4Net is a bit odd, but Nuget Gallery will reveal that Log4Net 2.0.3 has _Log4net [1.2.13] 2.0.3_ as package name. This means that `Common.Logging.Log4Net1213` is the correct logging adapter.
+2. In some cases the adapter may install the wrong version of Log4Net. If installing the adapter for 2.0.3, the version must be upped to this version too.
+
+Complete App.config with the Log4Net adapter installed and a `RollingFileAppender`:
+{% highlight xml %}
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <sectionGroup name="common">
+      <section name="logging" type="Common.Logging.ConfigurationSectionHandler, Common.Logging" />
+    </sectionGroup>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+  </configSections>
+
+  <common>
+    <logging>
+      <factoryAdapter type="Common.Logging.Log4Net.Log4NetLoggerFactoryAdapter, Common.Logging.Log4net1213">
+        <arg key="configType" value="INLINE" />
+      </factoryAdapter>
+    </logging>
+  </common>
+
+   <log4net>
+    <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
+      <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
+      <file value="${AppData}\Digipost\Signature\" />
+      <appendToFile value="true" />
+      <rollingStyle value="Date" />
+      <staticLogFileName value="false" />
+      <rollingStyle value="Composite" />
+      <param name="maxSizeRollBackups" value="10" />
+      <datePattern value="yyyy.MM.dd' signature-api-client-dotnet.log'" />
+      <maximumFileSize value="100MB" />
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
+      </layout>
+    </appender>
+   <root>
+      <appender-ref ref="RollingFileAppender"/>
+    </root>
+  </log4net>
+</configuration>
+
+{% endhighlight %}
+
+<h3 id="loggingrequestresponse">Logging request and response with Log4Net</h3>
+
+For initial integration and debugging purposes, it can be useful to log the actual request and response going over the wire. This can be enabled by creating a logger with the name `Digipost.Signature.Api.Client.RequestLogger`. See the following example for how to log requests to trace and file:
+
+{% highlight xml %}
+
+ <log4net>
+    <logger name="Digipost.Signature.Api.Client.RequestLogger">
+      <appender-ref ref="TraceAppender"/>
+      <appender-ref ref="RollingFileAppender"/>
+      <level value="DEBUG"/>
+    </logger>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5p %c %message%newline" />
+      </layout>
+    </appender>
+    <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
+      <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
+      <file value="${AppData}\Digipost\Signering\RequestLog\" />
+      <appendToFile value="true" />
+      <rollingStyle value="Date" />
+      <staticLogFileName value="false" />
+      <rollingStyle value="Composite" />
+      <param name="maxSizeRollBackups" value="10" />
+      <datePattern value="yyyy.MM.dd' signature-api-client-dotnet.log'" />
+      <maximumFFileSize value="100MB" />
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+      </layout>
+    </appender>
+  </log4net>
+
+{% endhighlight %}
+
+<blockquote>
+Warning: Enabling request logging should never be used in a production system. It will severely impact the performance of the client.	
+</blockquote>
+
+<h3 id="loggingdocumentbundle">Logging of document bundle</h3>
+
+Logging of document bundle can be enabled via the `ClientConfiguration`:
+
+{% highlight csharp %}
+
+var clientConfiguration = new ClientConfiguration(Environment.DifiQa, "3k 7f 30 dd 05 d3 b7 fc...");
+clientConfiguration.EnableDocumentBundleDiskDump("/directory/path/for/bundle/disk/dump");
+
+{% endhighlight %}
+
+<blockquote>
+Remember to only set the directory to save the disk dump. A new zip file will be placed there for each created signature job. 
+</blockquote>
+
+If you have special needs for the bundle other than just saving it to disk, add your own bundle processor to `ClientConfiguration.DocumentBundleProcessors`.
+
+
+

--- a/docs/_v1_7/index.html
+++ b/docs/_v1_7/index.html
@@ -1,10 +1,10 @@
 ---
 identifier: index
 layout: default
-redirect_from:
+redirect_from: /
 ---
 
-{% for dok in site.v1_6 %}
+{% for dok in site.v1_7 %}
 	{% if dok.identifier != 'index' %}
 		<section class="bs-docs-section">  
 	  		<h1 id="{{ dok.identifier }}" class="page-header">{{ dok.title}}</h1>


### PR DESCRIPTION
Legger til en oppdatert dokumentasjon som inneholder følgende:
- Fødselsnummer og epostadresse er gjort enda mer generisk slik at avsendere som integrerer skal skjønne at det er tulledata.
- `Difitest` skal brukes av avsendere i stedet for `Difiqa`. Dette gjenspeiler eksemplene nå.
- En liten presisering av at `NotificationsUsingLookup` kun kan brukes for offentlige.
- Nye headere som bruker Markdown, som gir bedre id på headere automagisk.