### PR TITLE
Loggoppgradering

### DIFF
--- a/Digipost.Signature.Api.Client.Core.Tests/Smoke/SmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/Smoke/SmokeTests.cs
@@ -4,33 +4,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests.Smoke
 {
     public class SmokeTests
     {
-        internal static Client ClientType
-        {
-            get
-            {
-                if (IsOnBuildServer())
-                {
-                    return Client.Qa;
-                }
-
-                return Client.Qa;
-            }
-        }
-
-        protected static bool IsOnBuildServer()
-        {
-            var isOnBuildServer = false;
-
-            const string buildServerUser = "administrator";
-            var currentUser = System.Environment.UserName.ToLower();
-            var isCurrentUserBuildServer = currentUser.Contains(buildServerUser);
-            if (isCurrentUserBuildServer)
-            {
-                isOnBuildServer = true;
-            }
-
-            return isOnBuildServer;
-        }
+        internal static Client ClientType => Client.Qa;
 
         internal static Uri GetUriFromRelativePath(string relativeUri)
         {

--- a/Digipost.Signature.Api.Client.Core/BaseClient.cs
+++ b/Digipost.Signature.Api.Client.Core/BaseClient.cs
@@ -55,7 +55,7 @@ namespace Digipost.Signature.Api.Client.Core
                 MutualTlsHandler(),
                 new XsdRequestValidationHandler(),
                 new UserAgentHandler(),
-                new LoggingHandler()
+                new LoggingHandler(ClientConfiguration)
             );
 
             client.Timeout = TimeSpan.FromMilliseconds(ClientConfiguration.HttpClientTimeoutInMilliseconds);

--- a/Digipost.Signature.Api.Client.Core/ClientConfiguration.cs
+++ b/Digipost.Signature.Api.Client.Core/ClientConfiguration.cs
@@ -75,5 +75,10 @@ namespace Digipost.Signature.Api.Client.Core
             var documentBundleToDiskProcessor = new DocumentBundleToDiskProcessor(directory);
             ((List<IDocumentBundleProcessor>) DocumentBundleProcessors).Add(documentBundleToDiskProcessor);
         }
+
+        /// <summary>
+        ///     Set to true to enable request and response logging with level DEBUG 
+        /// </summary>
+        public bool LogRequestAndResponse { get; set; } = false;
     }
 }

--- a/Digipost.Signature.Api.Client.Core/ClientConfiguration.cs
+++ b/Digipost.Signature.Api.Client.Core/ClientConfiguration.cs
@@ -51,6 +51,11 @@ namespace Digipost.Signature.Api.Client.Core
         public string ServerCertificateOrganizationNumber { get; } = "984661185";
 
         /// <summary>
+        ///     Set to true to enable request and response logging with level DEBUG
+        /// </summary>
+        public bool LogRequestAndResponse { get; set; } = false;
+
+        /// <summary>
         ///     All bundle processors used for processing document bundle zip files before they are sent to the service to create
         ///     signature jobs. Add a <see cref="IDocumentBundleProcessor">DocumentBundleProcessor</see> here if requirements are
         ///     more specific than what can be achieved from <see cref="EnableDocumentBundleDiskDump" />
@@ -75,10 +80,5 @@ namespace Digipost.Signature.Api.Client.Core
             var documentBundleToDiskProcessor = new DocumentBundleToDiskProcessor(directory);
             ((List<IDocumentBundleProcessor>) DocumentBundleProcessors).Add(documentBundleToDiskProcessor);
         }
-
-        /// <summary>
-        ///     Set to true to enable request and response logging with level DEBUG 
-        /// </summary>
-        public bool LogRequestAndResponse { get; set; } = false;
     }
 }

--- a/Digipost.Signature.Api.Client.Core/Internal/LoggingHandler.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/LoggingHandler.cs
@@ -10,14 +10,14 @@ namespace Digipost.Signature.Api.Client.Core.Internal
 {
     internal class LoggingHandler : DelegatingHandler
     {
-        public ClientConfiguration ClientConfiguration { get; }
-
         private static readonly ILog Log = LogManager.GetLogger("Digipost.Signature.Api.Client.RequestResponse");
 
         public LoggingHandler(ClientConfiguration clientClientConfiguration)
         {
             ClientConfiguration = clientClientConfiguration;
         }
+
+        public ClientConfiguration ClientConfiguration { get; }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -79,13 +79,19 @@ namespace Digipost.Signature.Api.Client.Core.Internal
             var contentDescriptionAndData = new List<KeyValuePair<string, string>>();
             var hasContent = (request.Content != null) && request.Content.IsMimeMultipartContent();
 
-            if (!hasContent) { return contentDescriptionAndData; }
+            if (!hasContent)
+            {
+                return contentDescriptionAndData;
+            }
 
             var multipart = await request.Content.ReadAsMultipartAsync().ConfigureAwait(false);
 
             foreach (var httpContent in multipart.Contents)
             {
-                if (httpContent.Headers.ContentType.MediaType != MediaType.ApplicationXml) { continue; }
+                if (httpContent.Headers.ContentType.MediaType != MediaType.ApplicationXml)
+                {
+                    continue;
+                }
 
                 contentDescriptionAndData.AddRange(SerializeHeaders(request.Content.Headers));
                 contentDescriptionAndData.Add(new KeyValuePair<string, string>(null, $"{await GetContentData(httpContent).ConfigureAwait(false)}"));
@@ -105,7 +111,7 @@ namespace Digipost.Signature.Api.Client.Core.Internal
 
         private static KeyValuePair<string, string> GetResponseStatusCodeDescription(HttpResponseMessage response)
         {
-            return new KeyValuePair<string, string>("StatusCode", $"{(int)response.StatusCode}, {response.StatusCode}");
+            return new KeyValuePair<string, string>("StatusCode", $"{(int) response.StatusCode}, {response.StatusCode}");
         }
 
         private static List<KeyValuePair<string, string>> GetHeadersDescription(HttpHeaders headers)

--- a/Digipost.Signature.Api.Client.Core/Internal/LoggingHandler.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/LoggingHandler.cs
@@ -35,54 +35,80 @@ namespace Digipost.Signature.Api.Client.Core.Internal
             Log.Debug($"Outgoing: {requestData}");
         }
 
-        private static async Task<string> GetRequestData(HttpRequestMessage request)
-        {
-            var keyValuePairs = new List<KeyValuePair<string, string>>
-            {
-                new KeyValuePair<string, string>("Method", $"{request.Method}, {request.RequestUri}")
-            };
-
-            keyValuePairs.AddRange(SerializeHeaders(request.Headers));
-
-            if ((request.Content != null) && request.Content.IsMimeMultipartContent())
-            {
-                var multipart = await request.Content.ReadAsMultipartAsync().ConfigureAwait(false);
-
-                foreach (var httpContent in multipart.Contents)
-                {
-                    if (httpContent.Headers.ContentType.MediaType == MediaType.ApplicationXml)
-                    {
-                        keyValuePairs.AddRange(SerializeHeaders(request.Content.Headers));
-                        keyValuePairs.Add(new KeyValuePair<string, string>(null, $"{await GetContentData(httpContent).ConfigureAwait(false)}"));
-                    }
-                }
-            }
-
-            return FormatHttpData(keyValuePairs);
-        }
-
         private static async Task LogResponse(HttpResponseMessage response)
         {
             var responseData = await GetResponseData(response).ConfigureAwait(false);
             Log.Debug($"Incoming: {responseData}");
         }
 
+        private static async Task<string> GetRequestData(HttpRequestMessage request)
+        {
+            var requestDescriptionsAndData = new List<KeyValuePair<string, string>>();
+            requestDescriptionsAndData.Add(GetRequestMethodDescription(request));
+            requestDescriptionsAndData.AddRange(GetHeadersDescription(request.Headers));
+            requestDescriptionsAndData.AddRange(await GetRequestContentHeadersDescriptionAndData(request));
+
+            return FormatHttpData(requestDescriptionsAndData);
+        }
+
         private static async Task<string> GetResponseData(HttpResponseMessage response)
         {
-            var keyValuePairs = new List<KeyValuePair<string, string>>
-            {
-                new KeyValuePair<string, string>("StatusCode", $"{(int) response.StatusCode}, {response.StatusCode}")
-            };
-
-            keyValuePairs.AddRange(SerializeHeaders(response.Headers));
-            keyValuePairs.AddRange(SerializeHeaders(response.Content.Headers));
-
-            if ((response.Content != null) && (response.Content.Headers.ContentType?.MediaType == MediaType.ApplicationXml))
-            {
-                keyValuePairs.Add(new KeyValuePair<string, string>(null, $"{await GetContentData(response.Content).ConfigureAwait(false)}"));
-            }
+            var keyValuePairs = new List<KeyValuePair<string, string>>();
+            keyValuePairs.Add(GetResponseStatusCodeDescription(response));
+            keyValuePairs.AddRange(GetHeadersDescription(response.Headers));
+            keyValuePairs.AddRange(GetResponseContentHeaders(response));
+            keyValuePairs.Add(await GetResponseDataIfAny(response, keyValuePairs));
 
             return FormatHttpData(keyValuePairs);
+        }
+
+        private static KeyValuePair<string, string> GetRequestMethodDescription(HttpRequestMessage request)
+        {
+            return new KeyValuePair<string, string>("Method", $"{request.Method}, {request.RequestUri}");
+        }
+
+        private static async Task<IEnumerable<KeyValuePair<string, string>>> GetRequestContentHeadersDescriptionAndData(HttpRequestMessage request)
+        {
+            var contentDescriptionAndData = new List<KeyValuePair<string, string>>();
+            var hasContent = (request.Content != null) && request.Content.IsMimeMultipartContent();
+
+            if (!hasContent) { return contentDescriptionAndData; }
+
+            var multipart = await request.Content.ReadAsMultipartAsync().ConfigureAwait(false);
+
+            foreach (var httpContent in multipart.Contents)
+            {
+                if (httpContent.Headers.ContentType.MediaType != MediaType.ApplicationXml) { continue; }
+
+                contentDescriptionAndData.AddRange(SerializeHeaders(request.Content.Headers));
+                contentDescriptionAndData.Add(new KeyValuePair<string, string>(null, $"{await GetContentData(httpContent).ConfigureAwait(false)}"));
+            }
+
+            return contentDescriptionAndData;
+        }
+
+        private static async Task<KeyValuePair<string, string>> GetResponseDataIfAny(HttpResponseMessage response, List<KeyValuePair<string, string>> keyValuePairs)
+        {
+            var hasContent = (response.Content != null) && (response.Content.Headers.ContentType?.MediaType == MediaType.ApplicationXml);
+
+            if (!hasContent) return new KeyValuePair<string, string>();
+
+            return new KeyValuePair<string, string>(null, $"{await GetContentData(response.Content).ConfigureAwait(false)}");
+        }
+
+        private static KeyValuePair<string, string> GetResponseStatusCodeDescription(HttpResponseMessage response)
+        {
+            return new KeyValuePair<string, string>("StatusCode", $"{(int)response.StatusCode}, {response.StatusCode}");
+        }
+
+        private static List<KeyValuePair<string, string>> GetHeadersDescription(HttpHeaders headers)
+        {
+            return SerializeHeaders(headers);
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> GetResponseContentHeaders(HttpResponseMessage response)
+        {
+            return SerializeHeaders(response.Content.Headers);
         }
 
         private static List<KeyValuePair<string, string>> SerializeHeaders(HttpHeaders headers)
@@ -110,7 +136,7 @@ namespace Digipost.Signature.Api.Client.Core.Internal
 
         private static Task<string> GetContentData(HttpContent httpContent)
         {
-            return httpContent != null ? httpContent.ReadAsStringAsync() : Task.FromResult(string.Empty);
+            return httpContent?.ReadAsStringAsync() ?? Task.FromResult(string.Empty);
         }
     }
 }

--- a/Digipost.Signature.Api.Client.Core/Internal/LoggingHandler.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/LoggingHandler.cs
@@ -10,18 +10,25 @@ namespace Digipost.Signature.Api.Client.Core.Internal
 {
     internal class LoggingHandler : DelegatingHandler
     {
-        private static readonly ILog Log = LogManager.GetLogger("Digipost.Signature.Api.Client.RequestLogger");
+        public ClientConfiguration ClientConfiguration { get; }
+
+        private static readonly ILog Log = LogManager.GetLogger("Digipost.Signature.Api.Client.RequestResponse");
+
+        public LoggingHandler(ClientConfiguration clientClientConfiguration)
+        {
+            ClientConfiguration = clientClientConfiguration;
+        }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (Log.IsDebugEnabled)
+            if (ClientConfiguration.LogRequestAndResponse && Log.IsDebugEnabled)
             {
                 await LogRequest(request).ConfigureAwait(false);
             }
 
             var httpResponseMessage = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            if (Log.IsDebugEnabled)
+            if (ClientConfiguration.LogRequestAndResponse && Log.IsDebugEnabled)
             {
                 await LogResponse(httpResponseMessage).ConfigureAwait(false);
             }

--- a/Digipost.Signature.Api.Client.Direct.Tests/Smoke/DirectClientSmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Smoke/DirectClientSmokeTests.cs
@@ -9,7 +9,7 @@ using Environment = Digipost.Signature.Api.Client.Core.Environment;
 
 namespace Digipost.Signature.Api.Client.Direct.Tests.Smoke
 {
-    public class DirectSmokeTestsFixture : SmokeTests, IDisposable
+    public class DirectSmokeTestsFixture : SmokeTests
     {
         public DirectSmokeTestsFixture()
         {
@@ -18,16 +18,15 @@ namespace Digipost.Signature.Api.Client.Direct.Tests.Smoke
 
         public TestHelper TestHelper { get; set; }
 
-        public void Dispose()
-        {
-        }
-
         private static DirectClient DirectClient(Environment environment)
         {
             var sender = new Sender("988015814");
-            var clientConfig = new ClientConfiguration(environment, CoreDomainUtility.GetTestIntegrasjonSertifikat(), sender);
-            var client = new DirectClient(clientConfig);
-            return client;
+            var clientConfig = new ClientConfiguration(environment, CoreDomainUtility.GetTestIntegrasjonSertifikat(), sender)
+            {
+                LogRequestAndResponse = true
+            };
+
+            return new DirectClient(clientConfig);
         }
 
         private static DirectClient GetDirectClient()

--- a/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
@@ -110,6 +110,8 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.Smoke
                         throw new ArgumentOutOfRangeException();
                 }
 
+                _portalClient.ClientConfiguration.LogRequestAndResponse = true;
+
                 return _portalClient;
             }
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,8 +10,8 @@ licenseUrl: http://opensource.org/licenses/MIT
 
 baseurl: "/signature-api-client-dotnet"
 
-currentVersion: "1.7"
-versions: ["1.7", "1.6", "1.5", "1.4"]
+currentVersion: "2"
+versions: ["2","1.7", "1.6", "1.5", "1.4"]
 
 collections:
   v1_4:
@@ -26,6 +26,9 @@ collections:
   v1_7:
     output: true
     permalink: /v1.7/
+  v2:
+    output: true
+    permalink: /v2/
 
 # list of additional links on the right of the top menu
 headerLinks:

--- a/docs/_v2/1_setup.md
+++ b/docs/_v2/1_setup.md
@@ -1,0 +1,42 @@
+---
+identifier: setup
+title: Initial setup
+layout: default
+---
+
+The client library is available as a nuget package. The client library (and associated nuget package) is updated regularly as new functionality is added. 
+
+
+To install the nuget package, follow these steps in Visual Studio:
+
+1. Select _TOOLS -> nuget Package Manager -> Manage nuget Packages Solution..._
+1. Search for _digipost-signature-api-client-dotnet_.
+* If you would like pre-releases of this package, make sure _Include Prerelease_ is enabled. Please refer to documentation for your version of Visual Studio for detailed instructions.
+1. Select _digipost-signature-api-client_ and click _Install_.
+
+### Install business certificate in certificate store
+
+<blockquote>SSL Certificates are small data files that digitally bind a cryptographic key to an organization's details. When installed on a web server, it activates the padlock and the https protocol (over port 443) and allows secure connections from a web server to a browser.</blockquote>
+
+To communicate over HTTPS you need to sign your request with a business certificate. The following steps will install the certificate in the your certificate store. This should be done on the server where your application will run.
+
+1.  Double-click on the actual certificate file (CertificateName.p12)
+1.  Save the sertificate in _Current User_ or _Local Machine_ and click _Next_ 
+1.  USe the suggested filename. Click _Next_
+1.  Enter password for private key and select _Mark this key as exportable ..._ Click _Next_
+1.  Select _Automatically select the certificate store based on the type of certificate_
+1.  Click _Next_ and _Finish_
+1.  Accept the certificate if prompted.
+1.  When prompted that the import was successful, click _Ok_
+
+### Use business certificate thumbprint
+
+1. Start mmc.exe (Click windowsbutton and type mmc.exe)
+1. _Choose File_ -> _Add/Remove Snap-in…_ (Ctrl + M)
+1. Mark certificate and click _Add >_
+1. If the certificate was installed in _Current User_ choose _My User Account_ and if installed on _Local Machine_ choose _Computer Account_. Then click _Finish_ and then _OK_
+1. Expand _Certificates_ node, select _Personal_ and open _Certificates_
+1. Double-click on the installed certificate
+1. Go to the _Details_ tab
+1. Scroll down to _Thumbprint_
+1. Copy the thumbprint

--- a/docs/_v2/2_direct_usecases.md
+++ b/docs/_v2/2_direct_usecases.md
@@ -1,0 +1,158 @@
+---
+identifier: directusecases
+title: Direct use cases
+layout: default
+---
+
+### Create Client Configuration
+
+{% highlight csharp %}
+
+const string organizationNumber = "123456789";
+const string certificateThumbprint = "3k 7f 30 dd 05 d3 b7 fc...";
+
+var clientConfiguration = new ClientConfiguration(
+    Environment.DifiTest,
+    certificateThumbprint,
+    new Sender(organizationNumber));
+
+{% endhighlight %}
+
+<blockquote>
+Note: If the sender changes per signature job created, the sender can be set on the job itself. The sender of the job will always take precedence over the sender in <code>ClientConfiguration</code>. This means that a default sender can be set in <code>ClientConfiguration</code> and, when required, on a specific job.   
+</blockquote>
+
+### Create signature job
+
+{% highlight csharp %}
+
+ClientConfiguration clientConfiguration = null; //As initialized earlier
+var directClient = new DirectClient(clientConfiguration);
+
+var documentToSign = new Document(
+    "Subject of Message", 
+    "This is the content", 
+    FileType.Pdf, 
+    @"C:\Path\ToDocument\File.pdf");
+
+var exitUrls = new ExitUrls(
+    new Uri("http://redirectUrl.no/onCompletion"), 
+    new Uri("http://redirectUrl.no/onCancellation"), 
+    new Uri("http://redirectUrl.no/onError")
+    );
+
+var signers = new List<Signer>
+{
+    new Signer(new PersonalIdentificationNumber("12345678910")),
+    new Signer(new PersonalIdentificationNumber("10987654321"))
+};
+
+var job = new Job(documentToSign, signers, "SendersReferenceToSignatureJob", exitUrls);
+
+var directJobResponse = await directClient.Create(job);
+
+{% endhighlight %}
+
+### Get direct job status
+
+The signing process is a synchrounous operation in the direct use case. There is no need to poll for changes to a signature job, as the status is well known to the sender of the job. As soon as the signer cancels, completes or an error occurs, the user is redirected to the respective Urls set in `ExitUrls`. A `status_query_token` parameter has been added to the url. Use this when requesting a status change.
+
+{% highlight csharp %}
+
+ClientConfiguration clientConfiguration = null; //As initialized earlier
+var directClient = new DirectClient(clientConfiguration);
+JobResponse jobResponse = null; //As initialized when creating signature job
+var statusQueryToken = "0A3BQ54C...";
+
+var jobStatusResponse =
+    await directClient.GetStatus(jobResponse.ResponseUrls.Status(statusQueryToken));
+
+var jobStatus = jobStatusResponse.Status;
+
+{% endhighlight %}
+
+### Get direct job status by polling
+
+If you, for any reason, are unable to retrieve status by using the status query token specified <a href="#uc03">above</a>, you may poll the service for any changes done to your organization's jobs. If the queue is empty, additional polling will give an exception.
+
+<blockquote>Note: For the job to be available in the polling queue, make sure to specify the job's <code>statusRetrievalMethod</code> as illustrated below.</blockquote>
+
+{% highlight csharp %}
+
+ClientConfiguration clientConfiguration = null; // As initialized earlier
+var directClient = new DirectClient(clientConfiguration);
+
+Document documentToSign = null; // As initialized earlier
+ExitUrls exitUrls = null; // As initialized earlier
+
+var signer = new PersonalIdentificationNumber("12345678910");
+
+var job = new Job(
+    documentToSign,
+    new List<Signer> {new Signer(signer)},
+    "SendersReferenceToSignatureJob",
+    exitUrls,
+    statusRetrievalMethod: StatusRetrievalMethod.Polling
+    );
+
+await directClient.Create(job);
+
+var changedJob = await directClient.GetStatusChange();
+
+if (changedJob.Status == JobStatus.NoChanges)
+{
+    // Queue is empty. Additional polling will result in blocking for a defined period.
+}
+
+// Repeat the above until signer signs the document
+
+changedJob = await directClient.GetStatusChange();
+
+if (changedJob.Status == JobStatus.CompletedSuccessfully)
+{
+    // Get PAdES
+}
+
+if (changedJob.GetSignatureFrom(signer).SignatureStatus.Equals(SignatureStatus.Signed))
+{
+    // Get XAdES
+}
+
+// Confirm status change to avoid receiving it again
+await directClient.Confirm(changedJob.References.Confirmation);
+
+{% endhighlight %}
+
+### Get Xades And Pades
+
+{% highlight csharp %}
+
+ClientConfiguration clientConfiguration = null; //As initialized earlier
+var directClient = new DirectClient(clientConfiguration);
+JobStatusResponse jobStatusResponse = null; // Result of requesting job status
+
+if (jobStatusResponse.Status == JobStatus.CompletedSuccessfully)
+{
+    var padesByteStream = await directClient.GetPades(jobStatusResponse.References.Pades);
+}
+
+var signature = jobStatusResponse.GetSignatureFrom(new PersonalIdentificationNumber("12345678910"));
+
+if (signature.Equals(SignatureStatus.Signed))
+{
+    var xadesByteStream = await directClient.GetXades(signature.XadesReference);
+}
+
+{% endhighlight %}
+
+### Confirm received signature job
+
+{% highlight csharp %}
+
+ClientConfiguration clientConfiguration = null; //As initialized earlier
+var directClient = new DirectClient(clientConfiguration);
+JobStatusResponse jobStatusResponse = null; // Result of requesting job status
+
+await directClient.Confirm(jobStatusResponse.References.Confirmation);
+
+{% endhighlight %}

--- a/docs/_v2/3_portal_usecases.md
+++ b/docs/_v2/3_portal_usecases.md
@@ -1,0 +1,116 @@
+---
+identifier: portalusecases
+title: Portal use cases
+layout: default
+---
+
+### Create Client Configuration
+
+{% highlight csharp %}
+
+const string organizationNumber = "123456789";
+const string certificateThumbprint = "3k 7f 30 dd 05 d3 b7 fc...";
+
+var clientConfiguration = new ClientConfiguration(
+    Environment.DifiTest,
+    certificateThumbprint,
+    new Sender(organizationNumber));
+{% endhighlight %}
+
+<blockquote>
+Note: If the sender changes per signature job created, the sender can be set on the job itself. The sender of the job will always take precedence over the sender in <code>ClientConfiguration</code>. This means that a default sender can be set in <code>ClientConfiguration</code> and, when required, on a specific job.   
+</blockquote>
+
+### Create and send portal signature job
+
+The following example shows how to create a document and send it to two signers.
+
+{% highlight csharp %}
+
+PortalClient portalClient = null; //As initialized earlier
+
+var documentToSign = new Document(
+    "Subject of Message",
+    "This is the content",
+    FileType.Pdf,
+    @"C:\Path\ToDocument\File.pdf"
+    );
+
+var signers = new List<Signer>
+{
+    new Signer(new PersonalIdentificationNumber("00000000000"), new NotificationsUsingLookup()),
+    new Signer(new PersonalIdentificationNumber("11111111111"), new Notifications(
+        new Email("test@example.com"),
+        new Sms("999999999")))
+};
+
+var portalJob = new Job(documentToSign, signers, "myReferenceToJob");
+
+var portalJobResponse = await portalClient.Create(portalJob);
+
+
+{% endhighlight %}
+
+> Note that only public organizations can do `NotificationsUsingLookup`.
+
+### Get portal job status change
+
+All changes to signature jobs will be added to a queue. You can poll for these changes. If the queue is empty, then additional polling will give an exception. The following example shows how this can be handled and examples of data to extract from a change response.
+
+{% highlight csharp %}
+
+PortalClient portalClient = null; //As initialized earlier
+
+var jobStatusChanged = await portalClient.GetStatusChange();
+
+if (jobStatusChanged.Status == JobStatus.NoChanges)
+{
+    //Queue is empty. Additional polling will result in blocking for a defined period.
+}
+else
+{
+    var signatureJobStatus = jobStatusChanged.Status;
+    var signatures = jobStatusChanged.Signatures;
+    var signatureOne = signatures.ElementAt(0);
+    var signatureOneStatus = signatureOne.SignatureStatus;
+}
+
+//Polling again:
+try
+{
+    var changeResponse2 = await portalClient.GetStatusChange();
+}
+catch (TooEagerPollingException eagerPollingException)
+{
+    var nextAvailablePollingTime = eagerPollingException.NextPermittedPollTime;
+}
+
+{% endhighlight %}
+
+### Get XAdES and PAdES
+
+When getting XAdES and PAdES for a `PortalJob`, remember that the XAdES is per signer, while there is only one PAdES. 
+
+{% highlight csharp %}
+
+PortalClient portalClient = null; //As initialized earlier
+var jobStatusChanged = await portalClient.GetStatusChange();
+
+//Get XAdES:
+var xades = await portalClient.GetXades(jobStatusChanged.Signatures.ElementAt(0).XadesReference);
+
+//Get PAdES:
+var pades = await portalClient.GetPades(jobStatusChanged.PadesReference);
+
+{% endhighlight %}
+
+### Confirm portal job
+
+{% highlight csharp %}
+
+PortalClient portalClient = null; //As initialized earlier
+var jobStatusChangeResponse = await portalClient.GetStatusChange();
+
+await portalClient.Confirm(jobStatusChangeResponse.ConfirmationReference);
+
+{% endhighlight %}

--- a/docs/_v2/4_Error_Handling.md
+++ b/docs/_v2/4_Error_Handling.md
@@ -1,0 +1,38 @@
+---
+identifier: errorhandling
+title: Error Handling
+layout: default
+---
+
+### Handling error
+
+There are differet forms of exceptions that can occur. Some are more specific than others. All exceptions related to client behavior inherits from `SignatureException`. 
+
+{% highlight csharp %}
+
+try
+{
+    //Some signature action
+}
+catch (BrokerNotAuthorizedException notAuthorizedException)
+{
+    //Not authorized to perform action. The correct access rights for organization are not set.
+}
+catch (UnexpectedResponseException unexpectedResponseException)
+{
+    //UnexpectedResponseException will normally contain an `Error` object giving a more detailed error description. If this error does not exist, 
+    // you can still get the status code and message.
+    var statusCode = unexpectedResponseException.StatusCode;
+    var responseMessage = unexpectedResponseException.Message;
+
+    if (unexpectedResponseException.Error != null)
+    {
+        var errorMessage = unexpectedResponseException.Error.Message;
+        var errorType = unexpectedResponseException.Error.Type;
+    }
+}
+catch (SignatureException exception)
+{
+   
+}
+{% endhighlight %}

--- a/docs/_v2/5_Logging.md
+++ b/docs/_v2/5_Logging.md
@@ -1,0 +1,122 @@
+---
+identifier: Logging
+title: Logging
+layout: default
+---
+
+
+### Logging request flow
+The client is using Common Logging API for .NET as an abstraction for logging. It is up to the user to implement the API with a logging framework.
+
+<blockquote>Common Logging API is a lightweight infrastructure logging platform that allows developers to focus on the logging requirements instead of the logging tools and required configuration. The Common Logging API abstracts the logging requirements of any project making it easy to swap logging providers.</blockquote>
+
+
+Enabling logging on level `DEBUG` will output positive results of requests and worse, `WARN` only failed requests or worse, while `ERROR` will only occur on failed requests to create a signature job. These loggers will be under the `Digipost.Signature.Api.Client` namespace. 
+
+### Implementing Log4Net
+1. Install Nuget-package `Common.Logging.Log4Net`. This will install the dependencies `Common.Logging.Core` and `Common.Logging`. Note that the versioning of Log4Net is a bit odd, but Nuget Gallery will reveal that Log4Net 2.0.3 has _Log4net [1.2.13] 2.0.3_ as package name. This means that `Common.Logging.Log4Net1213` is the correct logging adapter.
+2. In some cases the adapter may install the wrong version of Log4Net. If installing the adapter for 2.0.3, the version must be upped to this version too.
+
+Complete App.config with the Log4Net adapter installed and a `RollingFileAppender`:
+{% highlight xml %}
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <sectionGroup name="common">
+      <section name="logging" type="Common.Logging.ConfigurationSectionHandler, Common.Logging" />
+    </sectionGroup>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+  </configSections>
+
+  <common>
+    <logging>
+      <factoryAdapter type="Common.Logging.Log4Net.Log4NetLoggerFactoryAdapter, Common.Logging.Log4net1213">
+        <arg key="configType" value="INLINE" />
+      </factoryAdapter>
+    </logging>
+  </common>
+
+   <log4net>
+    <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
+      <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
+      <file value="${AppData}\Digipost\Signature\" />
+      <appendToFile value="true" />
+      <rollingStyle value="Date" />
+      <staticLogFileName value="false" />
+      <rollingStyle value="Composite" />
+      <param name="maxSizeRollBackups" value="10" />
+      <datePattern value="yyyy.MM.dd' signature-api-client-dotnet.log'" />
+      <maximumFileSize value="100MB" />
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
+      </layout>
+    </appender>
+   <root>
+      <appender-ref ref="RollingFileAppender"/>
+    </root>
+  </log4net>
+</configuration>
+
+{% endhighlight %}
+
+### Logging request and response with Log4Net
+
+For initial integration and debugging purposes, it can be useful to log the actual request and response going over the wire. This can be enabled by doing the following:
+
+* Set the property `ClientConfiguration.LogRequestAndResponse = true` and
+* Create a logger with the name `Digipost.Signature.Api.Client.RequestResponse`. See the following example for how to log requests to trace and file:
+
+{% highlight xml %}
+
+ <log4net>
+    <logger name="Digipost.Signature.Api.Client.RequestResponse">
+      <appender-ref ref="TraceAppender"/>
+      <appender-ref ref="RollingFileAppender"/>
+      <level value="DEBUG"/>
+    </logger>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5p %c %message%newline" />
+      </layout>
+    </appender>
+    <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
+      <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
+      <file value="${AppData}\Digipost\Signering\RequestLog\" />
+      <appendToFile value="true" />
+      <rollingStyle value="Date" />
+      <staticLogFileName value="false" />
+      <rollingStyle value="Composite" />
+      <param name="maxSizeRollBackups" value="10" />
+      <datePattern value="yyyy.MM.dd' signature-api-client-dotnet.log'" />
+      <maximumFFileSize value="100MB" />
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+      </layout>
+    </appender>
+  </log4net>
+
+{% endhighlight %}
+
+<blockquote>
+Warning: Enabling request logging should never be used in a production system. It will severely impact the performance of the client.	
+</blockquote>
+
+### Logging of document bundle
+
+Logging of document bundle can be enabled via the `ClientConfiguration`:
+
+{% highlight csharp %}
+
+var clientConfiguration = new ClientConfiguration(Environment.DifiTest, "3k 7f 30 dd 05 d3 b7 fc...");
+clientConfiguration.EnableDocumentBundleDiskDump("/directory/path/for/bundle/disk/dump");
+
+{% endhighlight %}
+
+<blockquote>
+Remember to only set the directory to save the disk dump. A new zip file will be placed there for each created signature job. 
+</blockquote>
+
+If you have special needs for the bundle other than just saving it to disk, add your own bundle processor to `ClientConfiguration.DocumentBundleProcessors`.
+
+
+

--- a/docs/_v2/index.html
+++ b/docs/_v2/index.html
@@ -1,10 +1,10 @@
 ---
 identifier: index
 layout: default
-redirect_from:
+redirect_from: /
 ---
 
-{% for dok in site.v1_7 %}
+{% for dok in site.v2 %}
 	{% if dok.identifier != 'index' %}
 		<section class="bs-docs-section">  
 	  		<h1 id="{{ dok.identifier }}" class="page-header">{{ dok.title}}</h1>


### PR DESCRIPTION
- Legger til feltet `ClientConfiguration.LogRequestAndResponse` slik at man eksplisitt må sette logging for request og response
- Fjerner logikk for hvilket miljø vi skal kjøre mot i smoke-testene, siden denne ikke brukes mer.
- Oppdaterer selvfølgelig dokumentasjonen
- Prøver meg på å rydde litt opp i LoggingHandler, men er ikke helt enig med meg selv på hvor godt jeg synes det gikk. Bakgrunnen for dette var at jeg ikke _husket hvordan ting hang sammen_ (😡). Hvordan vi traverserer alle dataene er litt ullent, så prøvde å gi litt mer kontekst for det som skjer.

**To små obs**:
- Litt hardt at dette skal bli en 2.0-versjon, synes du? Da kan jeg informere om at det skal komme bedre sertifikatvalideringsfeilmeldinger, men det kommer i separat PR. Har ikke bumpet versjonsnummeret på klienten enda, serru.
- For dokumentasjonen er det bare ca 4 linjer som er endret.

Disse her:
```
For initial integration and debugging purposes, it can be useful to log the actual request and response going over the wire. This can be enabled by creating a logger with the name `Digipost.Signature.Api.Client.RequestLogger`. See the following example for how to log requests to trace and file:
```
er endret til
```
For initial integration and debugging purposes, it can be useful to log the actual request and response going over the wire. This can be enabled by doing the following:

* Set the property `ClientConfiguration.LogRequestAndResponse = true` and
* Create a logger with the name `Digipost.Signature.Api.Client.RequestResponse`. See the following example for how to log requests to trace and file:
```