### PR TITLE
Only allowed chain certificates in Environment, not validator

### DIFF
--- a/Digipost.Signature.Api.Client.Core.Tests/EnvironmentTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/EnvironmentTests.cs
@@ -19,9 +19,8 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 var environment = Environment.Localhost;
 
                 //Assert
-                Assert.NotNull(environment.CertificateChainValidator);
                 Assert.Equal(url, environment.Url);
-                Assert.Equal(certificates, environment.CertificateChainValidator.CertificateStore);
+                Assert.Equal(certificates, environment.AllowedChainCertificates);
             }
 
             [Fact]
@@ -35,9 +34,8 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 var environment = Environment.DifiQa;
 
                 //Assert
-                Assert.NotNull(environment.CertificateChainValidator);
                 Assert.Equal(url, environment.Url);
-                Assert.Equal(certificates, environment.CertificateChainValidator.CertificateStore);
+                Assert.Equal(certificates, environment.AllowedChainCertificates);
             }
 
             [Fact]
@@ -51,9 +49,8 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 var environment = Environment.DifiTest;
 
                 //Assert
-                Assert.NotNull(environment.CertificateChainValidator);
                 Assert.Equal(url, environment.Url);
-                Assert.Equal(certificates, environment.CertificateChainValidator.CertificateStore);
+                Assert.Equal(certificates, environment.AllowedChainCertificates);
             }
 
             [Fact]
@@ -67,9 +64,8 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 var environment = Environment.Production;
 
                 //Assert
-                Assert.NotNull(environment.CertificateChainValidator);
                 Assert.Equal(url, environment.Url);
-                Assert.Equal(certificates, environment.CertificateChainValidator.CertificateStore);
+                Assert.Equal(certificates, environment.AllowedChainCertificates);
             }
         }
     }

--- a/Digipost.Signature.Api.Client.Core/BaseClient.cs
+++ b/Digipost.Signature.Api.Client.Core/BaseClient.cs
@@ -78,7 +78,7 @@ namespace Digipost.Signature.Api.Client.Core
         {
             var x509Certificate2 = new X509Certificate2(certificate);
             var isValidCertificate = CertificateValidator.IsValidCertificate(x509Certificate2, ClientConfiguration.ServerCertificateOrganizationNumber);
-            var isValidCertificateChain = new CertificateChainValidator(ClientConfiguration.Environment.CertificateChainValidator.CertificateStore).IsValidChain(x509Certificate2);
+            var isValidCertificateChain = new CertificateChainValidator(ClientConfiguration.Environment.AllowedChainCertificates).IsValidChain(x509Certificate2);
 
             return isValidCertificate && isValidCertificateChain;
         }

--- a/Digipost.Signature.Api.Client.Core/Environment.cs
+++ b/Digipost.Signature.Api.Client.Core/Environment.cs
@@ -1,34 +1,38 @@
 ﻿using System;
-using Difi.Felles.Utility;
+using System.Security.Cryptography.X509Certificates;
 using Difi.Felles.Utility.Utilities;
 
 namespace Digipost.Signature.Api.Client.Core
 {
-    public class Environment : AbstractEnvironment
+    public class Environment
     {
-        private Environment(CertificateChainValidator certificateChainValidator, Uri url)
+        private Environment(X509Certificate2Collection allowedChainCertificates, Uri url)
         {
+            AllowedChainCertificates = allowedChainCertificates;
             Url = url;
-            CertificateChainValidator = certificateChainValidator;
         }
 
+        public Uri Url { get; set; }
+
+        public X509Certificate2Collection AllowedChainCertificates { get; set; }
+
         internal static Environment Localhost => new Environment(
-            new CertificateChainValidator(CertificateChainUtility.FunksjoneltTestmiljøSertifikater()),
+            CertificateChainUtility.FunksjoneltTestmiljøSertifikater(),
             new Uri("https://172.16.91.1:8443")
         );
 
         public static Environment DifiTest => new Environment(
-            new CertificateChainValidator(CertificateChainUtility.FunksjoneltTestmiljøSertifikater()),
+            CertificateChainUtility.FunksjoneltTestmiljøSertifikater(),
             new Uri("https://api.difitest.signering.posten.no")
         );
 
         public static Environment DifiQa => new Environment(
-            new CertificateChainValidator(CertificateChainUtility.FunksjoneltTestmiljøSertifikater()),
+            CertificateChainUtility.FunksjoneltTestmiljøSertifikater(),
             new Uri("https://api.difiqa.signering.posten.no")
         );
 
         public static Environment Production => new Environment(
-            new CertificateChainValidator(CertificateChainUtility.ProduksjonsSertifikater()),
+            CertificateChainUtility.ProduksjonsSertifikater(),
             new Uri("https://api.signering.posten.no")
         );
 


### PR DESCRIPTION
The `CertificateChainValidator` is no longer used as it is created within the `CertificateValidator`. It also makes more sense that `Environment` only contains the certificates related to that environment and not the validator itself.