### PR TITLE
Legg til OnBehalfOf for portaljobber til manifestet

### DIFF
--- a/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
@@ -44,12 +44,16 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(0).Identifier).Value,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true,
                         },
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(1).Identifier).Value,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true,
                         }
                     },
                     requiredauthentication = authenticationlevel.Item4,
@@ -97,12 +101,16 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(0).Identifier).Value,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true,
                         },
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(1).Identifier).Value,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true,
                         }
                     },
                     availability = new availability
@@ -157,12 +165,16 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(0).Identifier).Value,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true,
                         },
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(1).Identifier).Value,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true,
                         }
                     },
                     availability = new availability
@@ -215,12 +227,16 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(0).Identifier).Value,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true,
                         },
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(1).Identifier).Value,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true,
                         }
                     },
                     availability = new availability
@@ -263,12 +279,16 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(0).Identifier).Value, order = 1,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true
                         },
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(1).Identifier).Value, order = 2,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true
                         }
                     }
                 };
@@ -318,14 +338,18 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(0).Identifier).Value,
                             Item1 = new notificationsusinglookup {email = new enabled()},
                             signaturetype = signaturetype.ADVANCED_ELECTRONIC_SIGNATURE,
-                            signaturetypeSpecified = true
+                            signaturetypeSpecified = true,
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true
                         },
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(1).Identifier).Value,
                             Item1 = new notificationsusinglookup {email = new enabled()},
                             signaturetype = signaturetype.AUTHENTICATED_ELECTRONIC_SIGNATURE,
-                            signaturetypeSpecified = true
+                            signaturetypeSpecified = true,
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true,
                         }
                     }
                 };
@@ -367,12 +391,16 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(0).Identifier).Value,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true,
                         },
                         new portalsigner
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(1).Identifier).Value,
-                            Item1 = new notificationsusinglookup {email = new enabled()}
+                            Item1 = new notificationsusinglookup {email = new enabled()},
+                            onbehalfof = signingonbehalfof.SELF,
+                            onbehalfofSpecified = true,
                         }
                     }
                 };
@@ -540,7 +568,41 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         {
                             new email {address = "email@example.com"}
                         }
-                    }
+                    },
+                    onbehalfofSpecified = true,
+                };
+
+                //Act
+                var actual = DataTransferObjectConverter.ToDataTransferObject(source);
+
+                //Assert
+                var comparator = new Comparator();
+                IEnumerable<IDifference> differences;
+                comparator.AreEqual(expected, actual, out differences);
+                Assert.Equal(0, differences.Count());
+            }
+
+            [Fact]
+            public void Converts_on_behalf_on()
+            {
+                //Arrange
+                var source = new Signer(
+                        new ContactInformation {Email = new Email("email@example.com")}
+                    )
+                    {OnBehalfOf = OnBehalfOf.Other};
+
+                var expected = new portalsigner
+                {
+                    Item = new enabled(),
+                    Item1 = new notifications
+                    {
+                        Items = new object[]
+                        {
+                            new email {address = "email@example.com"}
+                        }
+                    },
+                    onbehalfofSpecified = true,
+                    onbehalfof = signingonbehalfof.OTHER
                 };
 
                 //Act
@@ -573,9 +635,11 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         Items = new object[]
                         {
                             new email {address = "email@example.com"},
-                            new sms {number = "11111111"}
+                            new sms {number = "11111111"},
                         }
-                    }
+                    },
+                    onbehalfof = signingonbehalfof.SELF,
+                    onbehalfofSpecified = true,
                 };
 
                 //Act
@@ -605,7 +669,9 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         {
                             new sms {number = "11111111"}
                         }
-                    }
+                    },
+                    onbehalfof = signingonbehalfof.SELF,
+                    onbehalfofSpecified = true,
                 };
 
                 //Act
@@ -630,7 +696,9 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                     Item1 = new notifications
                     {
                         Items = new object[] {new email {address = ((ContactInformation) source.Identifier).Email.Address}}
-                    }
+                    },
+                    onbehalfof = signingonbehalfof.SELF,
+                    onbehalfofSpecified = true,
                 };
 
                 //Act
@@ -654,7 +722,9 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                 var expected = new portalsigner
                 {
                     Item = ((PersonalIdentificationNumber) source.Identifier).Value,
-                    Item1 = new notificationsusinglookup {email = new enabled()}
+                    Item1 = new notificationsusinglookup {email = new enabled()},
+                    onbehalfof = signingonbehalfof.SELF,
+                    onbehalfofSpecified = true,
                 };
 
                 //Act
@@ -684,7 +754,9 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         {
                             new email {address = source.Notifications.Email.Address}
                         }
-                    }
+                    },
+                    onbehalfof = signingonbehalfof.SELF,
+                    onbehalfofSpecified = true,
                 };
 
                 //Act

--- a/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
@@ -583,7 +583,7 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
             }
 
             [Fact]
-            public void Converts_on_behalf_on()
+            public void Converts_on_behalf_of()
             {
                 //Arrange
                 var source = new Signer(

--- a/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using Common.Logging;
 using Digipost.Signature.Api.Client.Core;
+using Digipost.Signature.Api.Client.Core.Enums;
 using Digipost.Signature.Api.Client.Core.Identifier;
 using Digipost.Signature.Api.Client.Core.Tests.Smoke;
 using Xunit;
@@ -48,7 +49,7 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.Smoke
         [Fact]
         public void Can_create_job_and_cancel()
         {
-            var signer = new Signer(new PersonalIdentificationNumber("12345678910"), new Notifications(new Email("email@example.com")));
+            var signer = new Signer(new PersonalIdentificationNumber("12345678910"), new Notifications(new Email("email@example.com"))) {OnBehalfOf = OnBehalfOf.Other};
 
             _fixture.TestHelper
                 .Create_job(signer)
@@ -60,7 +61,7 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.Smoke
         [Fact]
         public void Can_create_job_and_confirm()
         {
-            var signer = new Signer(new PersonalIdentificationNumber("12345678910"), new Notifications(new Email("email@example.com")));
+            var signer = new Signer(new PersonalIdentificationNumber("12345678910"), new Notifications(new Email("email@example.com"))) { OnBehalfOf = OnBehalfOf.Other };
 
             _fixture.TestHelper
                 .Create_job(signer)

--- a/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
@@ -97,6 +97,9 @@ namespace Digipost.Signature.Api.Client.Portal.DataTransferObjects
                 }
             }
 
+            dataTransferObject.onbehalfof = signer.OnBehalfOf.ToSigningonbehalfof();
+            dataTransferObject.onbehalfofSpecified = true;
+
             if (signer.Order != null)
             {
                 dataTransferObject.order = signer.Order.Value;


### PR DESCRIPTION

### 💰 Funksjonell beskrivelse av endringen

Feltet `OnBehalfOf` har rett og slett manglet, så dette har ikke vært mulig før
nå for portaljobber. En såkalt bug. Endringen innebærer bare at vi drar feltet rett inn serialiseringen av `Signer` for Portal. Problem fixed.