### PR TITLE
Enkel smoketest for testklient

### DIFF
--- a/Digipost.Signature.Api.Client.TestClient/Digipost.Signature.Api.Client.TestClient.csproj
+++ b/Digipost.Signature.Api.Client.TestClient/Digipost.Signature.Api.Client.TestClient.csproj
@@ -56,12 +56,31 @@
       <HintPath>..\packages\api-client-shared.3.0.0\lib\net46\Digipost.Api.Client.Shared.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Digipost.Signature.Api.Client.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
+      <HintPath>..\packages\digipost-signature-api-client.4.1.1\lib\net45\Digipost.Signature.Api.Client.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Digipost.Signature.Api.Client.Direct, Version=4.1.1.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
+      <HintPath>..\packages\digipost-signature-api-client.4.1.1\lib\net45\Digipost.Signature.Api.Client.Direct.dll</HintPath>
+    </Reference>
+    <Reference Include="Digipost.Signature.Api.Client.Portal, Version=4.1.1.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
+      <HintPath>..\packages\digipost-signature-api-client.4.1.1\lib\net45\Digipost.Signature.Api.Client.Portal.dll</HintPath>
+    </Reference>
+    <Reference Include="Digipost.Signature.Api.Client.Scripts, Version=4.1.1.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
+      <HintPath>..\packages\digipost-signature-api-client.4.1.1\lib\net45\Digipost.Signature.Api.Client.Scripts.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -81,16 +100,6 @@
       <Link>signingkey.snk</Link>
     </None>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj">
-      <Project>{2d13f732-6a85-4165-ae2f-a87c09750398}</Project>
-      <Name>Digipost.Signature.Api.Client.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Digipost.Signature.Api.Client.Portal\Digipost.Signature.Api.Client.Portal.csproj">
-      <Project>{d03be351-ca1f-4aac-968a-d3a0d8cd5197}</Project>
-      <Name>Digipost.Signature.Api.Client.Portal</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Digipost.Signature.Api.Client.TestClient/Program.cs
+++ b/Digipost.Signature.Api.Client.TestClient/Program.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Common.Logging;
 using Digipost.Signature.Api.Client.Core;
+using Digipost.Signature.Api.Client.Core.Enums;
+using Digipost.Signature.Api.Client.Core.Identifier;
 using Digipost.Signature.Api.Client.Portal;
 using Environment = Digipost.Signature.Api.Client.Core.Environment;
 
@@ -19,10 +22,31 @@ namespace Digipost.Signature.Api.Client.TestClient
             Log.Warn("Warn logging");
             Log.Error("Error logging");
             Log.Fatal("Fatal logging");
-            var client = new PortalClient(new ClientConfiguration(Environment.DifiQa, "‎2d 7f 30 dd 05 d3 b7 fc 7a e5 97 3a 73 f8 49 08 3b 20 40 ed", new Sender("123456789")));
+
+            var stringPrivateOrganizationNumber = "088015814";
+            var stringPublicOrganizationNumber = "988015814";
+
+            var testEnvironment = Environment.DifiTest;
+            testEnvironment.Url = new Uri("https://api.test.signering.posten.no");
+
+            var client = new PortalClient(
+                new ClientConfiguration(testEnvironment, "‎2d 7f 30 dd 05 d3 b7 fc 7a e5 97 3a 73 f8 49 08 3b 20 40 ed", 
+                new Sender(stringPublicOrganizationNumber))
+            );
+
+            var signer = new Signer(new PersonalIdentificationNumber("01043100358"), new Notifications(new Email("email@example.com"))) { OnBehalfOf = OnBehalfOf.Other };
+
+            var created = client.Create(new Job(
+                new Document("Et signeringsoppdrag", "Her kommer en melding", FileType.Pdf, @"\\vmware-host\Shared Folders\Downloads\00370726201232902222.pdf"),
+                new List<Signer>() {signer},
+                "Avsenders referance", new Sender(stringPrivateOrganizationNumber))).Result;
+
+            var status = client.GetStatusChange(new Sender(stringPrivateOrganizationNumber)).Result;
+            
+
 
             Console.WriteLine("Finished with loggah ...");
-            Console.ReadLine();
+            //Console.ReadLine();
         }
     }
 }

--- a/Digipost.Signature.Api.Client.TestClient/packages.config
+++ b/Digipost.Signature.Api.Client.TestClient/packages.config
@@ -4,5 +4,8 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Log4Net1213" version="3.3.1" targetFramework="net45" />
+  <package id="digipost-signature-api-client" version="4.1.1" targetFramework="net46" />
   <package id="log4net" version="2.0.8" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Det hender seg at vi ønsker å teste at alle binding redirects og imports
for biblioteket fungerer som de skal. Da er det veldig kjekt å ha et
prosjekt som bruker nuget-pakken og ikke klasser i projsektet. Dette
gjør vi nå. Det er kanskje litt uheldig at dette ikke vil fungere rett
ut av boksen for alle, men da kan det testes med minimalt med effort.
#MVP
