### PR TITLE
Fjerner Newtonsoft.json

### DIFF
--- a/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
+++ b/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
@@ -51,9 +51,6 @@
     <Reference Include="Digipost.Signature.Api.Client.Scripts, Version=4.2.0.140, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
       <HintPath>..\packages\digipost-signature-api-client.4.2.0.140-beta\lib\net45\Digipost.Signature.Api.Client.Scripts.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Digipost.Signature.Api.Client.Docs/packages.config
+++ b/Digipost.Signature.Api.Client.Docs/packages.config
@@ -5,5 +5,4 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
   <package id="digipost-signature-api-client" version="4.2.0.140-beta" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net461" />
 </packages>

--- a/Digipost.Signature.Api.Client.TestClient/Digipost.Signature.Api.Client.TestClient.csproj
+++ b/Digipost.Signature.Api.Client.TestClient/Digipost.Signature.Api.Client.TestClient.csproj
@@ -56,24 +56,20 @@
       <HintPath>..\packages\api-client-shared.3.0.0\lib\net46\Digipost.Api.Client.Shared.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Digipost.Signature.Api.Client.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
-      <HintPath>..\packages\digipost-signature-api-client.4.1.1\lib\net45\Digipost.Signature.Api.Client.Core.dll</HintPath>
+    <Reference Include="Digipost.Signature.Api.Client.Core, Version=4.2.0.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
+      <HintPath>..\packages\digipost-signature-api-client.4.2.0\lib\net45\Digipost.Signature.Api.Client.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Digipost.Signature.Api.Client.Direct, Version=4.1.1.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
-      <HintPath>..\packages\digipost-signature-api-client.4.1.1\lib\net45\Digipost.Signature.Api.Client.Direct.dll</HintPath>
+    <Reference Include="Digipost.Signature.Api.Client.Direct, Version=4.2.0.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
+      <HintPath>..\packages\digipost-signature-api-client.4.2.0\lib\net45\Digipost.Signature.Api.Client.Direct.dll</HintPath>
     </Reference>
-    <Reference Include="Digipost.Signature.Api.Client.Portal, Version=4.1.1.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
-      <HintPath>..\packages\digipost-signature-api-client.4.1.1\lib\net45\Digipost.Signature.Api.Client.Portal.dll</HintPath>
+    <Reference Include="Digipost.Signature.Api.Client.Portal, Version=4.2.0.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
+      <HintPath>..\packages\digipost-signature-api-client.4.2.0\lib\net45\Digipost.Signature.Api.Client.Portal.dll</HintPath>
     </Reference>
-    <Reference Include="Digipost.Signature.Api.Client.Scripts, Version=4.1.1.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
-      <HintPath>..\packages\digipost-signature-api-client.4.1.1\lib\net45\Digipost.Signature.Api.Client.Scripts.dll</HintPath>
+    <Reference Include="Digipost.Signature.Api.Client.Scripts, Version=4.2.0.0, Culture=neutral, PublicKeyToken=13a04c7692843c1c, processorArchitecture=MSIL">
+      <HintPath>..\packages\digipost-signature-api-client.4.2.0\lib\net45\Digipost.Signature.Api.Client.Scripts.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Digipost.Signature.Api.Client.TestClient/packages.config
+++ b/Digipost.Signature.Api.Client.TestClient/packages.config
@@ -4,8 +4,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Log4Net1213" version="3.3.1" targetFramework="net45" />
-  <package id="digipost-signature-api-client" version="4.1.1" targetFramework="net46" />
+  <package id="digipost-signature-api-client" version="4.2.0" targetFramework="net46" />
   <package id="log4net" version="2.0.8" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net46" />
 </packages>

--- a/signature-api-client.nuspec
+++ b/signature-api-client.nuspec
@@ -15,7 +15,6 @@
                 <dependency id="Common.Logging" version="[3.3.1,4)" />
                 <dependency id="Common.Logging.Core" version="[3.3.1,4)" />
                 <dependency id="Microsoft.AspNet.WebApi.Client" version="[5.2.3,6)" />
-                <dependency id="Newtonsoft.Json" version="[6.0.4,11)" />
                 <dependency id="api-client-shared" version="[3.0.0,4.0.0)" />
             </group>
         </dependencies>


### PR DESCRIPTION
Usikker på hvorfor vi har hatt det inne, men det er i alle fall ikke nødvendig nå mer. Kanskje fordi vi har importert .NET-pakken på et tidligere tidspunkt. Kom gjerne med innspill om det er jeg som har et tilfelle av cerebral flatulens her, men jeg kan ikke se hva vi bruker det til. Dette fordi #135, hvor en avsender bruker en nyere versjon av avhengigheten enn det vi tillater. Vi bruker den ikke, så jeg bare fjernet den.