### PR TITLE
Sørger for at `order`-attributt blir med i manifestet

### DIFF
--- a/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
@@ -281,6 +281,7 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(0).Identifier).Value,
                             order = 1,
+                            orderSpecified = true,
                             Item1 = new notificationsusinglookup {email = new enabled()},
                             onbehalfof = signingonbehalfof.SELF,
                             onbehalfofSpecified = true
@@ -289,6 +290,7 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.DataTransferObjects
                         {
                             Item = ((PersonalIdentificationNumber) source.Signers.ElementAt(1).Identifier).Value,
                             order = 2,
+                            orderSpecified = true,
                             Item1 = new notificationsusinglookup {email = new enabled()},
                             onbehalfof = signingonbehalfof.SELF,
                             onbehalfofSpecified = true

--- a/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Portal/DataTransferObjects/DataTransferObjectConverter.cs
@@ -109,6 +109,7 @@ namespace Digipost.Signature.Api.Client.Portal.DataTransferObjects
             if (signer.Order != null)
             {
                 dataTransferObject.order = signer.Order.Value;
+                dataTransferObject.orderSpecified = true;
             }
 
             if (signer.SignatureType != null)


### PR DESCRIPTION
Som rapportert i https://github.com/digipost/signature-api-client-dotnet/issues/141 ble ikke `order`-attributtet med i manifestet selv om det spesifiseres på undertegneren. Dette er nå fikset. Manifest ser sånn ut hvis `order` settes til `1`:

```diff
<?xml version="1.0" encoding="utf-8"?>
<portal-signature-job-manifest xmlns="http://signering.posten.no/schema/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
	<signers>
-		<signer>
+		<signer order="1">
			<personal-identification-number>12345678910</personal-identification-number>
			<notifications>
				<email address="email@example.com"/>
			</notifications>
			<on-behalf-of>OTHER</on-behalf-of>
		</signer>
	</signers>
…
```