### PR TITLE
Bedre dok for installasjon av bibliotek

### DIFF
--- a/Digipost.Signature.Api.Client.Direct.Tests/Smoke/DirectClientSmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Smoke/DirectClientSmokeTests.cs
@@ -40,7 +40,7 @@ namespace Digipost.Signature.Api.Client.Direct.Tests.Smoke
 
         private readonly DirectSmokeTestsFixture _fixture;
 
-        [Fact(Skip = "Doesn't run on CI yet due to incomplete TLS/certificate setup")]
+        [Fact()]
         public void Can_create_job_with_multiple_signers()
         {
             var signer1 = new PersonalIdentificationNumber("12345678910");

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
       jekyll-seo-tag (~> 2.0)
     jekyll-titles-from-headings (0.5.1)
       jekyll (~> 3.3)
-    jekyll-watch (2.0.0)
+    jekyll-watch (2.1.2)
       listen (~> 3.0)
     jemoji (0.10.1)
       gemoji (~> 3.0)
@@ -205,11 +205,11 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.11.3)
     multipart-post (2.0.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    octokit (4.12.0)
+    octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    pathutil (0.16.1)
+    pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
     rb-fsevent (0.10.3)
@@ -245,4 +245,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.16.5
+   1.17.1

--- a/docs/_v5_x/1_setup.md
+++ b/docs/_v5_x/1_setup.md
@@ -8,17 +8,12 @@ layout: default
 
 The client library is available as a nuget package. The client library (and associated nuget package) is updated regularly as new functionality is added.
 
-
-To install the nuget package, follow these steps in Visual Studio:
-
-1. Select _TOOLS -> nuget Package Manager -> Manage nuget Packages Solution..._
-1. Search for _digipost-signature-api-client-dotnet_.
-* If you would like pre-releases of this package, make sure _Include Pre-release_ is enabled. Please refer to documentation for your version of Visual Studio for detailed instructions.
-1. Select _digipost-signature-api-client_ and click _Install_.
+The library has several packages with the prefix `Digipost.Signature.Api.Client`. If you are using the portal cases, use `Digipost.Signature.Api.Client.Portal`, and for direct cases, use `Digipost.Signature.Api.Client.Direct`. 
 
 ## Set up business certificate
 
-Choose one of the options below
+As a sending organization, you must authenticate with an organization certificate issued by [Commfides](https://www.commfides.com/en/commfides-virksomhetssertifikat/) or [Buypass](https://www.buypass.com/). To install it properly on the host computer, please choose one of the options below:
+
 - [Using .NET user-secrets (All platforms)](#using-net-user-secrets-all-platforms)
 - [In certificate store (Windows only)](#in-certificate-store-windows-only)
 


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Gi nytt navn på Nuget-pakker i dokumentasjon, peker på linker for uthenting av virksomhetssertifikat og oppdaterer avhengigheter i samme slengen.