### PR TITLE
Tester å sjekke annen versjonsannotering for å tvinge samme versjon

### DIFF
--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.*"/>
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.*"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="2.*"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.*"/>
         <PackageReference Include="System.Net.Requests" Version="4.*"/>
         <PackageReference Include="System.Security.Cryptography.Xml" Version="4.*"/>
         <PackageReference Include="api-client-shared" Version="4.0.0"/>

--- a/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
+++ b/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
@@ -7,9 +7,9 @@
 
     <ItemGroup>
         <PackageReference Include="api-client-shared" Version="4.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="2.*"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.*"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.*"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.*"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.*"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.*"/>
 
         <PackageReference Include="Digipost.Signature.Api.Client.Core" Version="5.*"/>
     </ItemGroup>


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Snurper inn hvilke versjoner av avhengighet for logging som vi kan bruke. Gjør at vi ikke får manglende dll-er under bygging. 
