### PR TITLE
Oppdaterer til tag-styrt releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,30 +4,39 @@ solution: api-client-shared.sln
 mono: none
 git:
   submodules: false
-dotnet: 2.1.403
+dotnet: 2.1.502
 before_install:
   # Change github url to https for submodules
-- sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-- git submodule update --init --recursive
+  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+  - git submodule update --init --recursive
 
   # Decrypt private key used for tests
-- openssl aes-256-cbc -K $encrypted_3afad0b3f334_key -iv $encrypted_3afad0b3f334_iv -in Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12.enc -out Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12 -d
+  - openssl aes-256-cbc -K $encrypted_3afad0b3f334_key -iv $encrypted_3afad0b3f334_iv -in Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12.enc -out Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12 -d
 
-- ./travis-deploy/patch-assembly-version.sh Directory.Build.props $TRAVIS_BRANCH ${TRAVIS_BUILD_NUMBER}
+  - ./travis-deploy/patch-assembly-version.sh Directory.Build.props $TRAVIS_TAG
 
 install:
-- dotnet restore
-    
+  - dotnet restore
+
 script:
   - set -e #Makes sure we get a fail fast if some of the scripts fails
+
+  # Build
   - dotnet build -c Release
+
+  # Setup
   - ./travis-deploy/add-secrets.sh
   - find /home/travis/.microsoft
   - cat /home/travis/.microsoft/usersecrets/organization-certificate/secrets.json
+
+  # Test
   - dotnet test Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
   - dotnet test Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
   - dotnet test Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
-  - PROJECT_DIRECTORIES="Digipost.Signature.Api.Client.Core Digipost.Signature.Api.Client.Direct
-      Digipost.Signature.Api.Client.Portal Digipost.Signature.Api.Client.Resources Digipost.Signature.Api.Client.Scripts"
-    && ./travis-deploy/pack-and-push.sh $TRAVIS_BRANCH $NUGET_API_KEY $TRAVIS_BUILD_DIR
-      "${PROJECT_DIRECTORIES}"
+
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: ./travis-deploy/pack-and-push.sh $TRAVIS_TAG $NUGET_API_KEY $TRAVIS_BUILD_DIR Digipost.Signature.Api.Client.Core Digipost.Signature.Api.Client.Direct Digipost.Signature.Api.Client.Portal Digipost.Signature.Api.Client.Resources Digipost.Signature.Api.Client.Scripts
+  on:
+    tags: true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp2.1</TargetFramework>
 
-        <Version>5.0.3.0</Version>
-        <AssemblyVersion>5.0.3.0</AssemblyVersion>
+        <Version>0.0.0.0</Version>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
 
         <Authors>Digipost AS</Authors>
         <Company>Posten Norge AS</Company>


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Vi forenkler det som forenkles kan. Primær driver for dette er er at alle merger fra oppgraderinger av avhengigheter gjennom dependabot gir røde bygg. Skikkelig støyende. Hvorfor? Fordi merge til master releaser til versjon satt i koden. Men den er ikke endret så da får vi feilmelding fra Nuget.

Hvis versjon tidligere var satt til f.eks. `5.2.0` i koden så ville_
- Merge med `master` release versjon `5.2.0.0` til Nuget.
- Merge med `beta` release versjon `5.2.0.0-beta` til Nuget.

Dette var bra tidligere, men nå blir det litt for kronglete. Nytt regime er:
- _Hvis noe tagges, release den taggen til Nuget._

### 🏆 Interessante highlights

Det er mulig dette ikke fungerer helt 100. Det vet jeg ikke før det blir prodsatt. Endringene er hovedsaklig i [travis-deploy-repoet](https://github.com/digipost/travis-deploy/pull/3)
