### PR TITLE
Fjerner setting av TLS 1.2

### DIFF
--- a/Digipost.Signature.Api.Client.Core.Tests/BaseClientTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/BaseClientTests.cs
@@ -14,7 +14,6 @@ namespace Digipost.Signature.Api.Client.Core.Tests
             public void Initializes_with_properties()
             {
                 //Arrange
-                var tlsSetup = SecurityProtocolType.Tls12;
                 var clientConfiguration = new ClientConfiguration(Environment.DifiQa, GetBringCertificate())
                 {
                     HttpClientTimeoutInMilliseconds = 1441
@@ -25,7 +24,6 @@ namespace Digipost.Signature.Api.Client.Core.Tests
 
                 //Assert
                 Assert.Equal(clientConfiguration, clientStub.ClientConfiguration);
-                Assert.Equal(tlsSetup, ServicePointManager.SecurityProtocol);
                 Assert.NotNull(clientStub.RequestHelper);
                 Assert.Equal(clientConfiguration.HttpClientTimeoutInMilliseconds, clientStub.HttpClient.Timeout.TotalMilliseconds);
             }

--- a/Digipost.Signature.Api.Client.Core/BaseClient.cs
+++ b/Digipost.Signature.Api.Client.Core/BaseClient.cs
@@ -26,8 +26,6 @@ namespace Digipost.Signature.Api.Client.Core
             _logger = loggerFactory.CreateLogger<BaseClient>();
             _loggerFactory = loggerFactory;
 
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
             ClientConfiguration = clientConfiguration;
             HttpClient = MutualTlsClient();
             RequestHelper = new RequestHelper(HttpClient, _loggerFactory);


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Det er uheldig at vi setter `ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12` i klienten. Dette setter innstillingen også for appen som bruker klientbiblioteket. Dette er uheldig og bør styres av avsender. Dokumentasjon for dette skal lages. Denne fiksen er et resultat av en svært god beskrivelse i #217. 

En avsender kan uansett bare sette den til noe annet etter at `BaseClient` er initialisert for å revertere denne uheldige endringen. Siden vi ikke har fått noen tilbakemeldinger om dette utenom #217, så foreslår jeg at denne fiksen ikke er tilbakevirkende.

### 🏆 Interessante highlights

Ingen.

### 🤷‍♀️ Anbefalt fremgangsmåte

Kun 2 linjer endring. 


### 👀 Eksempler og screenshots

...

### ⚙️ Avhengigheter 

Ingen avhengigheter.

### 🚔 Sikkerhet

Det er backend som sørger for sikkerheten her. Dette er bare for å forhindre at klientbiblioteket mikker med appen som bruker det.