### PR TITLE
Handle general error from empty response content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
 
   # Test
   - dotnet test Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
-  - dotnet test Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
+  - dotnet test Digipost.Signature.Api.Client.Archive.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
   - dotnet test Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
   - dotnet test Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,15 @@ script:
   - cat /home/travis/.microsoft/usersecrets/organization-certificate/secrets.json
 
   # Test
-  - dotnet test Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
   - dotnet test Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
+  - dotnet test Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
+  - dotnet test Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
   - dotnet test Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
 
 
 deploy:
   skip_cleanup: true
   provider: script
-  script: ./travis-deploy/pack-and-push.sh $TRAVIS_TAG $NUGET_API_KEY $TRAVIS_BUILD_DIR Digipost.Signature.Api.Client.Core Digipost.Signature.Api.Client.Direct Digipost.Signature.Api.Client.Portal Digipost.Signature.Api.Client.Resources Digipost.Signature.Api.Client.Scripts
+  script: ./travis-deploy/pack-and-push.sh $TRAVIS_TAG $NUGET_API_KEY $TRAVIS_BUILD_DIR Digipost.Signature.Api.Client.Core Archive Digipost.Signature.Api.Client.Direct Digipost.Signature.Api.Client.Portal Digipost.Signature.Api.Client.Resources Digipost.Signature.Api.Client.Scripts
   on:
     tags: true

--- a/Digipost.Signature.Api.Client.Archive.Tests/Smoke/TestHelper.cs
+++ b/Digipost.Signature.Api.Client.Archive.Tests/Smoke/TestHelper.cs
@@ -2,7 +2,6 @@ using System;
 using Digipost.Signature.Api.Client.Core.Exceptions;
 using Digipost.Signature.Api.Client.Core.Tests.Smoke;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Digipost.Signature.Api.Client.Archive.Tests.Smoke
 {

--- a/Digipost.Signature.Api.Client.Archive.Tests/Smoke/TestHelper.cs
+++ b/Digipost.Signature.Api.Client.Archive.Tests/Smoke/TestHelper.cs
@@ -30,7 +30,7 @@ namespace Digipost.Signature.Api.Client.Archive.Tests.Smoke
         {
             var thrown = Assert.Throws<AggregateException>(() => Get_PAdES());
             var actualError = Assert.IsType<UnexpectedResponseException>(thrown.InnerException);
-            Assert.Equal("NotFound", actualError.Error.Code);
+            Assert.Equal("ARCHIVED_DOCUMENT_NOT_FOUND", actualError.Error.Code);
         }
     }
 

--- a/Digipost.Signature.Api.Client.Archive.Tests/Smoke/TestHelper.cs
+++ b/Digipost.Signature.Api.Client.Archive.Tests/Smoke/TestHelper.cs
@@ -2,6 +2,7 @@ using System;
 using Digipost.Signature.Api.Client.Core.Exceptions;
 using Digipost.Signature.Api.Client.Core.Tests.Smoke;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Digipost.Signature.Api.Client.Archive.Tests.Smoke
 {
@@ -29,7 +30,7 @@ namespace Digipost.Signature.Api.Client.Archive.Tests.Smoke
         {
             var thrown = Assert.Throws<AggregateException>(() => Get_PAdES());
             var actualError = Assert.IsType<UnexpectedResponseException>(thrown.InnerException);
-            Assert.Equal("ARCHIVED_DOCUMENT_NOT_FOUND", actualError.Error.Code);
+            Assert.Equal("NotFound", actualError.Error.Code);
         }
     }
 

--- a/Digipost.Signature.Api.Client.Core.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net;
 using Digipost.Signature.Api.Client.Core.Internal.DataTransferObjects;
 using Digipost.Signature.Api.Client.Core.Tests.Utilities.CompareObjects;
 using Schemas;
@@ -29,7 +30,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests.DataTransferObjects
                 };
 
                 //Act
-                var actual = DataTransferObjectConverter.FromDataTransferObject(source);
+                var actual = DataTransferObjectConverter.FromDataTransferObject(source, new HttpStatusCode());
 
                 //Assert
                 var compartor = new Comparator();

--- a/Digipost.Signature.Api.Client.Core.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/DataTransferObjects/DataTransferObjectConverterTests.cs
@@ -30,7 +30,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests.DataTransferObjects
                 };
 
                 //Act
-                var actual = DataTransferObjectConverter.FromDataTransferObject(source, new HttpStatusCode());
+                var actual = DataTransferObjectConverter.FromDataTransferObject(source);
 
                 //Assert
                 var compartor = new Comparator();

--- a/Digipost.Signature.Api.Client.Core.Tests/RequestHelperTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/RequestHelperTests.cs
@@ -90,7 +90,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests
             }
 
             [Fact]
-            public async Task Returns_unexpected_response_exception_without_error_and_code_on_not_xml_result()
+            public async Task Returns_unexpected_response_exception_with_standard_error_and_code_on_not_xml_result()
             {
                 //Arrange
                 var internalServerErrorResponse = new FakeHttpClientHandlerForInternalServerErrorResponse();
@@ -101,7 +101,9 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 var unexpectedResponseException = (UnexpectedResponseException) exception;
 
                 //Assert
-                Assert.Null(unexpectedResponseException.Error);
+                Assert.Equal(unexpectedResponseException.Error.Type, "Content-Type: Unknown");
+                Assert.Equal(unexpectedResponseException.Error.Code, internalServerErrorResponse.ResultCode.ToString());
+                Assert.Equal(unexpectedResponseException.Error.Message, "Unknown message");
                 Assert.Equal(internalServerErrorResponse.ResultCode, unexpectedResponseException.StatusCode);
             }
 

--- a/Digipost.Signature.Api.Client.Core.Tests/RequestHelperTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/RequestHelperTests.cs
@@ -101,7 +101,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 var unexpectedResponseException = (UnexpectedResponseException) exception;
 
                 //Assert
-                Assert.Equal(Error.unknown, unexpectedResponseException.Error);
+                Assert.Equal(Error.Unknown, unexpectedResponseException.Error);
                 Assert.Equal(internalServerErrorResponse.ResultCode, unexpectedResponseException.StatusCode);
             }
 

--- a/Digipost.Signature.Api.Client.Core.Tests/RequestHelperTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/RequestHelperTests.cs
@@ -90,7 +90,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests
             }
 
             [Fact]
-            public async Task Returns_unexpected_response_exception_without_error_and_code_on_not_xml_result()
+            public async Task Returns_unexpected_response_exception_with_unknown_error_and_code_on_not_xml_result()
             {
                 //Arrange
                 var internalServerErrorResponse = new FakeHttpClientHandlerForInternalServerErrorResponse();
@@ -101,7 +101,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 var unexpectedResponseException = (UnexpectedResponseException) exception;
 
                 //Assert
-                Assert.Null(unexpectedResponseException.Error);
+                Assert.Equal(Error.unknown, unexpectedResponseException.Error);
                 Assert.Equal(internalServerErrorResponse.ResultCode, unexpectedResponseException.StatusCode);
             }
 

--- a/Digipost.Signature.Api.Client.Core.Tests/RequestHelperTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/RequestHelperTests.cs
@@ -81,7 +81,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 var requestHelper = new RequestHelper(new HttpClient(errorResponse), new NullLoggerFactory());
 
                 //Act
-                var exception = requestHelper.HandleGeneralException(await errorResponse.GetContent().ReadAsStringAsync().ConfigureAwait(false), errorResponse.ResultCode.Value);
+                var exception = requestHelper.HandleGeneralException(errorResponse.ResultCode.Value, await errorResponse.GetContent().ReadAsStringAsync().ConfigureAwait(false));
                 var unexpectedResponseException = (UnexpectedResponseException) exception;
 
                 //Assert
@@ -97,7 +97,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 var requestHelper = new RequestHelper(new HttpClient(internalServerErrorResponse), new NullLoggerFactory());
 
                 //Act
-                var exception = requestHelper.HandleGeneralException(await internalServerErrorResponse.GetContent().ReadAsStringAsync().ConfigureAwait(false), internalServerErrorResponse.ResultCode.Value);
+                var exception = requestHelper.HandleGeneralException(internalServerErrorResponse.ResultCode.Value, await internalServerErrorResponse.GetContent().ReadAsStringAsync().ConfigureAwait(false));
                 var unexpectedResponseException = (UnexpectedResponseException) exception;
 
                 //Assert
@@ -113,7 +113,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 var requestHelper = new RequestHelper(new HttpClient(brokerNotAuthorizedResponse), new NullLoggerFactory());
 
                 //Act
-                var exception = requestHelper.HandleGeneralException(await brokerNotAuthorizedResponse.GetContent().ReadAsStringAsync().ConfigureAwait(false), brokerNotAuthorizedResponse.ResultCode.Value);
+                var exception = requestHelper.HandleGeneralException(brokerNotAuthorizedResponse.ResultCode.Value, await brokerNotAuthorizedResponse.GetContent().ReadAsStringAsync().ConfigureAwait(false));
 
                 //Assert
                 Assert.IsType<BrokerNotAuthorizedException>(exception);

--- a/Digipost.Signature.Api.Client.Core.Tests/RequestHelperTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/RequestHelperTests.cs
@@ -90,7 +90,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests
             }
 
             [Fact]
-            public async Task Returns_unexpected_response_exception_with_standard_error_and_code_on_not_xml_result()
+            public async Task Returns_unexpected_response_exception_without_error_and_code_on_not_xml_result()
             {
                 //Arrange
                 var internalServerErrorResponse = new FakeHttpClientHandlerForInternalServerErrorResponse();
@@ -101,9 +101,7 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 var unexpectedResponseException = (UnexpectedResponseException) exception;
 
                 //Assert
-                Assert.Equal(unexpectedResponseException.Error.Type, "Content-Type: Unknown");
-                Assert.Equal(unexpectedResponseException.Error.Code, internalServerErrorResponse.ResultCode.ToString());
-                Assert.Equal(unexpectedResponseException.Error.Message, "Unknown message");
+                Assert.Null(unexpectedResponseException.Error);
                 Assert.Equal(internalServerErrorResponse.ResultCode, unexpectedResponseException.StatusCode);
             }
 

--- a/Digipost.Signature.Api.Client.Core/Error.cs
+++ b/Digipost.Signature.Api.Client.Core/Error.cs
@@ -2,7 +2,7 @@
 {
     public class Error
     {
-        public static readonly Error unknown = new Error(){Code = "Unknown", Message = "Unknown", Type = "Unknown"};
+        public static readonly Error Unknown = new Error(){Code = "Unknown", Message = "Unknown", Type = "Unknown"};
      
         public string Code { get; set; }
 

--- a/Digipost.Signature.Api.Client.Core/Error.cs
+++ b/Digipost.Signature.Api.Client.Core/Error.cs
@@ -2,7 +2,7 @@
 {
     public class Error
     {
-        public static readonly Error unknown = new Error(){Code = "Unknown", Message = "Unknown", Type = "Unknown"};
+        public static readonly Error unknown = new Error(){ Code = "Unknown", Message = "Unknown", Type = "Unknown" };
      
         public string Code { get; set; }
 

--- a/Digipost.Signature.Api.Client.Core/Error.cs
+++ b/Digipost.Signature.Api.Client.Core/Error.cs
@@ -2,6 +2,8 @@
 {
     public class Error
     {
+        public static readonly Error unknown = new Error(){Code = "Unknown", Message = "Unknown", Type = "Unknown"};
+     
         public string Code { get; set; }
 
         public string Type { get; set; }

--- a/Digipost.Signature.Api.Client.Core/Error.cs
+++ b/Digipost.Signature.Api.Client.Core/Error.cs
@@ -2,7 +2,7 @@
 {
     public class Error
     {
-        public static readonly Error unknown = new Error(){ Code = "Unknown", Message = "Unknown", Type = "Unknown" };
+        public static readonly Error unknown = new Error(){Code = "Unknown", Message = "Unknown", Type = "Unknown"};
      
         public string Code { get; set; }
 

--- a/Digipost.Signature.Api.Client.Core/Internal/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/DataTransferObjects/DataTransferObjectConverter.cs
@@ -8,7 +8,7 @@ namespace Digipost.Signature.Api.Client.Core.Internal.DataTransferObjects
         {
             if (error == null)
             {
-                return Error.unknown;
+                return Error.Unknown;
             }
 
             return new Error

--- a/Digipost.Signature.Api.Client.Core/Internal/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/DataTransferObjects/DataTransferObjectConverter.cs
@@ -1,16 +1,17 @@
-﻿using Schemas;
+﻿using System.Net;
+using Schemas;
 
 namespace Digipost.Signature.Api.Client.Core.Internal.DataTransferObjects
 {
     public static class DataTransferObjectConverter
     {
-        public static Error FromDataTransferObject(error error)
+        public static Error FromDataTransferObject(error error, HttpStatusCode code)
         {
             return new Error
             {
-                Type = error.errortype,
-                Code = error.errorcode,
-                Message = error.errormessage
+                Type = error == null ? "Content-Type: Unknown" : error.errortype,
+                Code = error == null ? code.ToString() : error.errorcode,
+                Message = error == null ? "Unknown message" : error.errormessage
             };
         }
     }

--- a/Digipost.Signature.Api.Client.Core/Internal/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/DataTransferObjects/DataTransferObjectConverter.cs
@@ -13,9 +13,9 @@ namespace Digipost.Signature.Api.Client.Core.Internal.DataTransferObjects
 
             return new Error
             {
-                Type = error == null ? "Content-Type: Unknown" : error.errortype,
-                Code = error == null ? code.ToString() : error.errorcode,
-                Message = error == null ? "Unknown message" : error.errormessage
+                Type = error.errortype,
+                Code = error.errorcode,
+                Message = error.errormessage
             };
         }
     }

--- a/Digipost.Signature.Api.Client.Core/Internal/DataTransferObjects/DataTransferObjectConverter.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/DataTransferObjects/DataTransferObjectConverter.cs
@@ -1,12 +1,16 @@
-﻿using System.Net;
-using Schemas;
+﻿using Schemas;
 
 namespace Digipost.Signature.Api.Client.Core.Internal.DataTransferObjects
 {
     public static class DataTransferObjectConverter
     {
-        public static Error FromDataTransferObject(error error, HttpStatusCode code)
+        public static Error FromDataTransferObject(error error)
         {
+            if (error == null)
+            {
+                return Error.unknown;
+            }
+
             return new Error
             {
                 Type = error == null ? "Content-Type: Unknown" : error.errortype,

--- a/Digipost.Signature.Api.Client.Core/Internal/RequestHelper.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/RequestHelper.cs
@@ -99,7 +99,7 @@ namespace Digipost.Signature.Api.Client.Core.Internal
             Error error;
             try
             {
-                error = DataTransferObjectConverter.FromDataTransferObject(SerializeUtility.Deserialize<error>(requestContent), statusCode);
+                error = DataTransferObjectConverter.FromDataTransferObject(SerializeUtility.Deserialize<error>(requestContent));
                 _logger.LogWarning($"Error occured: {error}");
             }
             catch (Exception exception)

--- a/Digipost.Signature.Api.Client.Core/Internal/RequestHelper.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/RequestHelper.cs
@@ -108,7 +108,7 @@ namespace Digipost.Signature.Api.Client.Core.Internal
                 return new UnexpectedResponseException(requestContent, statusCode, exception);
             }
 
-            if (error.Code == BrokerNotAuthorized)
+            if (error != null && error.Code == BrokerNotAuthorized)
             {
                 return new BrokerNotAuthorizedException(error, statusCode);
             }

--- a/Digipost.Signature.Api.Client.Direct.Tests/Smoke/TestHelper.cs
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Smoke/TestHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Web;
 using Digipost.Signature.Api.Client.Core;
 using Digipost.Signature.Api.Client.Core.Identifier;

--- a/Digipost.Signature.Api.Client.Direct/DirectClient.cs
+++ b/Digipost.Signature.Api.Client.Direct/DirectClient.cs
@@ -89,7 +89,7 @@ namespace Digipost.Signature.Api.Client.Direct
                     _logger.LogDebug($"Requested status for JobId: {jobStatusResponse.JobId}, status was: {jobStatusResponse.Status}.");
                     return jobStatusResponse;
                 default:
-                    throw RequestHelper.HandleGeneralException(requestContent, requestResult.StatusCode);
+                    throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);
             }
         }
 
@@ -131,7 +131,7 @@ namespace Digipost.Signature.Api.Client.Direct
                 case HttpStatusCode.TooManyRequests:
                     throw CreateTooManyRequestsException(requestResult);
                 default:
-                    throw RequestHelper.HandleGeneralException(requestContent, requestResult.StatusCode);
+                    throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);
             }
         }
 

--- a/Digipost.Signature.Api.Client.Portal/PortalClient.cs
+++ b/Digipost.Signature.Api.Client.Portal/PortalClient.cs
@@ -88,7 +88,7 @@ namespace Digipost.Signature.Api.Client.Portal
                 case HttpStatusCode.TooManyRequests:
                     throw CreateTooManyRequestsException(requestResult);
                 default:
-                    throw RequestHelper.HandleGeneralException(requestContent, requestResult.StatusCode);
+                    throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);
             }
         }
 
@@ -184,7 +184,7 @@ namespace Digipost.Signature.Api.Client.Portal
                     _logger.LogDebug($"PortalJob was not cancelled. Job was already completed [CancellationReference: {cancellationReference.Url}].");
                     throw new JobCompletedException();
                 default:
-                    throw RequestHelper.HandleGeneralException(await requestResult.Content.ReadAsStringAsync().ConfigureAwait(false), requestResult.StatusCode);
+                    throw RequestHelper.HandleGeneralException(requestResult.StatusCode, await requestResult.Content.ReadAsStringAsync().ConfigureAwait(false));
             }
         }
 


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

RequestHelper genererer en UnexpectedResponseException med en generisk feil om request response returnerer tømt


