### PR TITLE
Multitarget .NET Standard 2.0 og .NET Core 2.1 for å understøtte .NET Framework 4.6.1+ og .NET Core 2.1+ samtidig

### DIFF
--- a/Digipost.Signature.Api.Client.Archive.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Archive.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <IsPackable>false</IsPackable>
+      <TargetFramework>netcoreapp2.1</TargetFramework>
+      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
+++ b/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.*" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
         <PackageReference Include="System.Net.Requests" Version="4.*" />
     </ItemGroup>
 

--- a/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
+++ b/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Archive</Title>
         <PackageId>Digipost.Signature.Api.Client.Archive</PackageId>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
+++ b/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Title>Digipost Signature Api Client Archive</Title>
         <PackageId>Digipost.Signature.Api.Client.Archive</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
+++ b/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
@@ -5,13 +5,9 @@
         <PackageId>Digipost.Signature.Api.Client.Archive</PackageId>
     </PropertyGroup>
 
-
-
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.*" />
         <PackageReference Include="System.Net.Requests" Version="4.*" />
-
-        <PackageReference Include="Digipost.Signature.Api.Client.Core" Version="6.*" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
@@ -3,8 +3,8 @@
     <PackageReference Include="api-client-shared" Version="4.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-      <PackageReference Include="NLog" Version="4.6.7" />
-      <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4" />
+    <PackageReference Include="NLog" Version="4.6.7" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
+++ b/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Core</Title>
         <PackageId>Digipost.Signature.Api.Client.Core</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -25,7 +26,7 @@
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-        <DocumentationFile>bin\Release\netcoreapp2.1\Digipost.Signature.Api.Client.Core.xml</DocumentationFile>
+        <DocumentationFile>bin\Release\$(TargetFramework)\Digipost.Signature.Api.Client.Core.xml</DocumentationFile>
         <noWarn>1591</noWarn>
     </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
+++ b/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
@@ -3,26 +3,26 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Core</Title>
         <PackageId>Digipost.Signature.Api.Client.Core</PackageId>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="api-client-shared" Version="4.0.0"/>
-        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7"/>
-        <PackageReference Include="System.Net.Requests" Version="4.3.0"/>
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="4.6.0"/>
+        <PackageReference Include="api-client-shared" Version="4.0.0" />
+        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+        <PackageReference Include="System.Net.Requests" Version="4.3.0" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="4.6.0" />
 
-        <PackageReference Include="NLog" Version="4.6.7"/>
-        <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0"/>
+        <PackageReference Include="NLog" Version="4.6.7" />
+        <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Resources\Digipost.Signature.Api.Client.Resources.csproj"/>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Scripts\Digipost.Signature.Api.Client.Scripts.csproj"/>
+        <ProjectReference Include="..\Digipost.Signature.Api.Client.Resources\Digipost.Signature.Api.Client.Resources.csproj" />
+        <ProjectReference Include="..\Digipost.Signature.Api.Client.Scripts\Digipost.Signature.Api.Client.Scripts.csproj" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -31,13 +31,13 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-        <None Update="Internal/Xsd/**/*" CopyToOutputDirectory="PreserveNewest"/>
+        <None Update="Internal/Xsd/**/*" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
     <ItemGroup>
-        <None Remove="Internal/Xsd/**/*"/>
+        <None Remove="Internal/Xsd/**/*" />
     </ItemGroup>
     <ItemGroup>
-        <EmbeddedResource Include="Internal/Xsd/**/*"/>
+        <EmbeddedResource Include="Internal/Xsd/**/*" />
     </ItemGroup>
 
 </Project>

--- a/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
+++ b/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
@@ -17,9 +17,6 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0"/>
-
-        <PackageReference Include="Digipost.Signature.Api.Client.Resources" Version="6.*"/>
-        <PackageReference Include="Digipost.Signature.Api.Client.Scripts" Version="6.*"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
@@ -4,9 +4,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
@@ -4,9 +4,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.*" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Direct</Title>
         <PackageId>Digipost.Signature.Api.Client.Direct</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -19,7 +20,7 @@
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-        <DocumentationFile>bin\Release\netcoreapp2.1\Digipost.Signature.Api.Client.Direct.xml</DocumentationFile>
+        <DocumentationFile>bin\Release\$(TargetFramework)\Digipost.Signature.Api.Client.Direct.xml</DocumentationFile>
         <noWarn>1591</noWarn>
     </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.*"/>
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.*"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.*"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0"/>
         <PackageReference Include="System.Net.Requests" Version="4.*"/>
         <PackageReference Include="System.Security.Cryptography.Xml" Version="4.*"/>
         <PackageReference Include="api-client-shared" Version="4.0.0"/>

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -3,20 +3,20 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Direct</Title>
         <PackageId>Digipost.Signature.Api.Client.Direct</PackageId>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.*"/>
-        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.*"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0"/>
-        <PackageReference Include="System.Net.Requests" Version="4.*"/>
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="4.*"/>
-        <PackageReference Include="api-client-shared" Version="4.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.*" />
+        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.*" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+        <PackageReference Include="System.Net.Requests" Version="4.*" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="4.*" />
+        <PackageReference Include="api-client-shared" Version="4.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
+        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -12,8 +12,6 @@
         <PackageReference Include="System.Net.Requests" Version="4.*"/>
         <PackageReference Include="System.Security.Cryptography.Xml" Version="4.*"/>
         <PackageReference Include="api-client-shared" Version="4.0.0"/>
-
-        <PackageReference Include="Digipost.Signature.Api.Client.Core" Version="6.*"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Direct/DirectClient.cs
+++ b/Digipost.Signature.Api.Client.Direct/DirectClient.cs
@@ -128,7 +128,11 @@ namespace Digipost.Signature.Api.Client.Direct
                     return CreateNoContentResponse(requestResult);
                 case HttpStatusCode.OK:
                     return CreateOkResponse(requestContent, requestResult);
-                case (HttpStatusCode)429: //HttpStatusCode.TooManyRequests
+#if NETCOREAPP
+                case HttpStatusCode.TooManyRequests:
+#else
+                case (HttpStatusCode)429:
+#endif
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Direct/DirectClient.cs
+++ b/Digipost.Signature.Api.Client.Direct/DirectClient.cs
@@ -122,13 +122,13 @@ namespace Digipost.Signature.Api.Client.Direct
 
             _logger.LogDebug($"Requesting status change on endpoint {requestResult.RequestMessage.RequestUri} ...");
 
-            switch (requestResult.StatusCode)
+            switch ((int)requestResult.StatusCode)
             {
-                case HttpStatusCode.NoContent:
+                case 204: //HttpStatusCode.NoContent
                     return CreateNoContentResponse(requestResult);
-                case HttpStatusCode.OK:
+                case 200: //HttpStatusCode.OK
                     return CreateOkResponse(requestContent, requestResult);
-                case HttpStatusCode.TooManyRequests:
+                case 429: //HttpStatusCode.TooManyRequests
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Direct/DirectClient.cs
+++ b/Digipost.Signature.Api.Client.Direct/DirectClient.cs
@@ -122,13 +122,13 @@ namespace Digipost.Signature.Api.Client.Direct
 
             _logger.LogDebug($"Requesting status change on endpoint {requestResult.RequestMessage.RequestUri} ...");
 
-            switch ((int)requestResult.StatusCode)
+            switch (requestResult.StatusCode)
             {
-                case 204: //HttpStatusCode.NoContent
+                case HttpStatusCode.NoContent:
                     return CreateNoContentResponse(requestResult);
-                case 200: //HttpStatusCode.OK
+                case HttpStatusCode.OK:
                     return CreateOkResponse(requestContent, requestResult);
-                case 429: //HttpStatusCode.TooManyRequests
+                case (HttpStatusCode)429: //HttpStatusCode.TooManyRequests
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
+++ b/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="api-client-shared" Version="4.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.*"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0"/>
     <PackageReference Include="NLog" Version="4.6.7"/>
     <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4"/>
   </ItemGroup>

--- a/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
+++ b/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
@@ -1,15 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <PackageReference Include="api-client-shared" Version="4.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.*"/>
-        <PackageReference Include="NLog" Version="4.6.7"/>
-        <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4"/>
-    </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Direct\Digipost.Signature.Api.Client.Direct.csproj"/>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Portal\Digipost.Signature.Api.Client.Portal.csproj"/>
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="api-client-shared" Version="4.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.*"/>
+    <PackageReference Include="NLog" Version="4.6.7"/>
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Direct\Digipost.Signature.Api.Client.Direct.csproj"/>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Portal\Digipost.Signature.Api.Client.Portal.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
+++ b/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
         <PackageReference Include="api-client-shared" Version="4.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.*"/>
         <PackageReference Include="NLog" Version="4.6.7"/>
         <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4"/>
     </ItemGroup>

--- a/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
@@ -20,6 +20,7 @@
     </ItemGroup>
 
     <PropertyGroup>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
+++ b/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Portal</Title>
         <PackageId>Digipost.Signature.Api.Client.Portal</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,7 +18,7 @@
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-        <DocumentationFile>bin\Release\netcoreapp2.1\Digipost.Signature.Api.Client.Portal.xml</DocumentationFile>
+        <DocumentationFile>bin\Release\$(TargetFramework)\Digipost.Signature.Api.Client.Portal.xml</DocumentationFile>
         <noWarn>1591</noWarn>
     </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
+++ b/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
@@ -3,18 +3,18 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Portal</Title>
         <PackageId>Digipost.Signature.Api.Client.Portal</PackageId>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="api-client-shared" Version="4.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0"/>
+        <PackageReference Include="api-client-shared" Version="4.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
+        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
+++ b/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
@@ -10,8 +10,6 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0"/>
-
-        <PackageReference Include="Digipost.Signature.Api.Client.Core" Version="6.*"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Portal/PortalClient.cs
+++ b/Digipost.Signature.Api.Client.Portal/PortalClient.cs
@@ -79,13 +79,13 @@ namespace Digipost.Signature.Api.Client.Portal
 
             _logger.LogDebug($"Requesting status change on endpoint {requestResult.RequestMessage.RequestUri} ...");
 
-            switch (requestResult.StatusCode)
+            switch ((int)requestResult.StatusCode)
             {
-                case HttpStatusCode.NoContent:
+                case 204: //HttpStatusCode.NoContent
                     return CreateNoContentResponse(requestResult);
-                case HttpStatusCode.OK:
+                case 200: //HttpStatusCode.OK
                     return CreateOkResponse(requestContent, requestResult);
-                case HttpStatusCode.TooManyRequests:
+                case 429: //HttpStatusCode.TooManyRequests
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Portal/PortalClient.cs
+++ b/Digipost.Signature.Api.Client.Portal/PortalClient.cs
@@ -85,7 +85,11 @@ namespace Digipost.Signature.Api.Client.Portal
                     return CreateNoContentResponse(requestResult);
                 case HttpStatusCode.OK:
                     return CreateOkResponse(requestContent, requestResult);
-                case (HttpStatusCode)429: // HttpStatusCode.TooManyRequests
+#if NETCOREAPP
+                case HttpStatusCode.TooManyRequests:
+#else
+                case (HttpStatusCode)429:
+#endif
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Portal/PortalClient.cs
+++ b/Digipost.Signature.Api.Client.Portal/PortalClient.cs
@@ -79,13 +79,13 @@ namespace Digipost.Signature.Api.Client.Portal
 
             _logger.LogDebug($"Requesting status change on endpoint {requestResult.RequestMessage.RequestUri} ...");
 
-            switch ((int)requestResult.StatusCode)
+            switch (requestResult.StatusCode)
             {
-                case 204: //HttpStatusCode.NoContent
+                case HttpStatusCode.NoContent:
                     return CreateNoContentResponse(requestResult);
-                case 200: //HttpStatusCode.OK
+                case HttpStatusCode.OK:
                     return CreateOkResponse(requestContent, requestResult);
-                case 429: //HttpStatusCode.TooManyRequests
+                case (HttpStatusCode)429: // HttpStatusCode.TooManyRequests
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
+++ b/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
+++ b/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
@@ -1,17 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <ItemGroup>
-        <PackageReference Include="Digipost.Signature.Api.Client.Direct" Version="6.*"/>
-        <PackageReference Include="Digipost.Signature.Api.Client.Portal" Version="6.*"/>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Direct\Digipost.Signature.Api.Client.Direct.csproj" />
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Portal\Digipost.Signature.Api.Client.Portal.csproj" />
 
-    <ItemGroup>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core.Tests\Digipost.Signature.Api.Client.Core.Tests.csproj"/>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
-    </ItemGroup>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Core.Tests\Digipost.Signature.Api.Client.Core.Tests.csproj"/>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
+  </ItemGroup>
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
 
 </Project>

--- a/Digipost.Signature.Api.Client.Resources/Digipost.Signature.Api.Client.Resources.csproj
+++ b/Digipost.Signature.Api.Client.Resources/Digipost.Signature.Api.Client.Resources.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Resources</Title>
         <PackageId>Digipost.Signature.Api.Client.Resources</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Scripts/Digipost.Signature.Api.Client.Scripts.csproj
+++ b/Digipost.Signature.Api.Client.Scripts/Digipost.Signature.Api.Client.Scripts.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Scripts</Title>
         <PackageId>Digipost.Signature.Api.Client.Scripts</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp2.1</TargetFramework>
 
-        <Version>0.0.0.0</Version>
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+        <Version>6.0.0.0</Version>
+        <AssemblyVersion>6.0.0.0</AssemblyVersion>
 
         <Authors>Digipost AS</Authors>
         <Company>Posten Norge AS</Company>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>6.0.0.0</Version>
-        <AssemblyVersion>6.0.0.0</AssemblyVersion>
+        <Version>0.0.0.0</Version>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
 
         <Authors>Digipost AS</Authors>
         <Company>Posten Norge AS</Company>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,5 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
-
         <Version>6.0.0.0</Version>
         <AssemblyVersion>6.0.0.0</AssemblyVersion>
 


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Støtte for bruk av bibliotekene fra .NET Framework 4.6.1 og nyere.

### 🤷‍♀️ Anbefalt fremgangsmåte

Hovedsakelig litt opprydding i referanser i prosjektfilene og oppdatering av prosjektene til å være multitarget. Ren teknisk gjennomgang samt evt. endringer i byggscript da det ikke er MSBuild som lager pakkene. Man må sjekke at pakkene som lages faktisk inneholder assemblies for både .NET Standard 2.0 og .NET Core 2.1.
