### PR TITLE
Target .NET Standard 2.0

### DIFF
--- a/.idea/.idea.signature-api-client/.idea/runConfigurations/Docker_Run_Tests.xml
+++ b/.idea/.idea.signature-api-client/.idea/runConfigurations/Docker_Run_Tests.xml
@@ -6,11 +6,11 @@
         <option name="containerName" value="docker-signering-tests" />
         <option name="entrypoint" value="" />
         <option name="imageTag" value="mcr.microsoft.com/dotnet/core/sdk:2.1" />
-        <option name="commandLineOptions" value="-w /app/" />
+        <option name="commandLineOptions" value="-w /signature-api-client-dotnet/" />
         <option name="volumeBindings">
           <list>
             <DockerVolumeBindingImpl>
-              <option name="containerPath" value="/app" />
+              <option name="containerPath" value="/signature-api-client-dotnet" />
               <option name="hostPath" value="$PROJECT_DIR$" />
             </DockerVolumeBindingImpl>
           </list>

--- a/.idea/.idea.signature-api-client/.idea/runConfigurations/Docker_Run_Tests.xml
+++ b/.idea/.idea.signature-api-client/.idea/runConfigurations/Docker_Run_Tests.xml
@@ -2,16 +2,36 @@
   <configuration default="false" name="Docker Run Tests" type="docker-deploy" factoryName="docker-image" server-name="Docker">
     <deployment type="docker-image">
       <settings>
-        <option name="command" value="dotnet test" />
+        <option name="command" value="bash" />
         <option name="containerName" value="docker-signering-tests" />
         <option name="entrypoint" value="" />
         <option name="imageTag" value="mcr.microsoft.com/dotnet/core/sdk:2.1" />
-        <option name="commandLineOptions" value="-w /signature-api-client-dotnet/" />
+        <option name="commandLineOptions" value="-it -w /signature-api-client-dotnet/" />
         <option name="volumeBindings">
           <list>
             <DockerVolumeBindingImpl>
               <option name="containerPath" value="/signature-api-client-dotnet" />
               <option name="hostPath" value="$PROJECT_DIR$" />
+            </DockerVolumeBindingImpl>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/root/.microsoft/usersecrets/organization-certificate/secrets.json" />
+              <option name="hostPath" value="$USER_HOME$/.microsoft/usersecrets/organization-certificate/secrets.json" />
+            </DockerVolumeBindingImpl>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="$USER_HOME$/Documents/sertifikater/Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12" />
+              <option name="hostPath" value="$USER_HOME$/Documents/sertifikater/Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12" />
+            </DockerVolumeBindingImpl>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/usr/local/share/ca-certificates/Buypass_Class_3_Test4_CA_3.crt" />
+              <option name="hostPath" value="$PROJECT_DIR$/Buypass_Class_3_Test4_CA_3.pem" />
+            </DockerVolumeBindingImpl>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/usr/local/share/ca-certificates/Buypass_Class_3_Test4_Root_CA.crt" />
+              <option name="hostPath" value="$PROJECT_DIR$/Buypass_Class_3_Test4_Root_CA.pem" />
+            </DockerVolumeBindingImpl>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/signature-api-client-dotnet/Digipost.Signature.Api.Client.Core.Tests/bin/Resources/Documents/Dokument.pdf" />
+              <option name="hostPath" value="$PROJECT_DIR$/Digipost.Signature.Api.Client.Core.Tests/Resources/Documents/Dokument.pdf" />
             </DockerVolumeBindingImpl>
           </list>
         </option>

--- a/.idea/.idea.signature-api-client/.idea/runConfigurations/Docker_Run_Tests.xml
+++ b/.idea/.idea.signature-api-client/.idea/runConfigurations/Docker_Run_Tests.xml
@@ -1,18 +1,17 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Docker Run Tests" type="docker-deploy" factoryName="docker-image" server-name="Docker">
-    <deployment type="docker-image">
+  <configuration default="false" name="Docker Run Tests" type="docker-deploy" factoryName="dockerfile" server-name="Docker">
+    <deployment type="dockerfile">
       <settings>
-        <option name="command" value="bash" />
-        <option name="containerName" value="docker-signering-tests" />
+        <option name="buildCliOptions" value="" />
+        <option name="command" value="" />
+        <option name="containerName" value="docker-tests" />
+        <option name="contextFolderPath" value="." />
         <option name="entrypoint" value="" />
-        <option name="imageTag" value="mcr.microsoft.com/dotnet/core/sdk:2.1" />
-        <option name="commandLineOptions" value="-it -w /signature-api-client-dotnet/" />
+        <option name="imageTag" value="test" />
+        <option name="commandLineOptions" value="" />
+        <option name="sourceFilePath" value="docker/tests/Dockerfile" />
         <option name="volumeBindings">
           <list>
-            <DockerVolumeBindingImpl>
-              <option name="containerPath" value="/signature-api-client-dotnet" />
-              <option name="hostPath" value="$PROJECT_DIR$" />
-            </DockerVolumeBindingImpl>
             <DockerVolumeBindingImpl>
               <option name="containerPath" value="/root/.microsoft/usersecrets/organization-certificate/secrets.json" />
               <option name="hostPath" value="$USER_HOME$/.microsoft/usersecrets/organization-certificate/secrets.json" />
@@ -20,18 +19,6 @@
             <DockerVolumeBindingImpl>
               <option name="containerPath" value="$USER_HOME$/Documents/sertifikater/Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12" />
               <option name="hostPath" value="$USER_HOME$/Documents/sertifikater/Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12" />
-            </DockerVolumeBindingImpl>
-            <DockerVolumeBindingImpl>
-              <option name="containerPath" value="/usr/local/share/ca-certificates/Buypass_Class_3_Test4_CA_3.crt" />
-              <option name="hostPath" value="$PROJECT_DIR$/Buypass_Class_3_Test4_CA_3.pem" />
-            </DockerVolumeBindingImpl>
-            <DockerVolumeBindingImpl>
-              <option name="containerPath" value="/usr/local/share/ca-certificates/Buypass_Class_3_Test4_Root_CA.crt" />
-              <option name="hostPath" value="$PROJECT_DIR$/Buypass_Class_3_Test4_Root_CA.pem" />
-            </DockerVolumeBindingImpl>
-            <DockerVolumeBindingImpl>
-              <option name="containerPath" value="/signature-api-client-dotnet/Digipost.Signature.Api.Client.Core.Tests/bin/Resources/Documents/Dokument.pdf" />
-              <option name="hostPath" value="$PROJECT_DIR$/Digipost.Signature.Api.Client.Core.Tests/Resources/Documents/Dokument.pdf" />
             </DockerVolumeBindingImpl>
           </list>
         </option>

--- a/.idea/.idea.signature-api-client/.idea/runConfigurations/Docker_Run_Tests.xml
+++ b/.idea/.idea.signature-api-client/.idea/runConfigurations/Docker_Run_Tests.xml
@@ -1,0 +1,22 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Docker Run Tests" type="docker-deploy" factoryName="docker-image" server-name="Docker">
+    <deployment type="docker-image">
+      <settings>
+        <option name="command" value="dotnet test" />
+        <option name="containerName" value="docker-signering-tests" />
+        <option name="entrypoint" value="" />
+        <option name="imageTag" value="mcr.microsoft.com/dotnet/core/sdk:2.1" />
+        <option name="commandLineOptions" value="-w /app/" />
+        <option name="volumeBindings">
+          <list>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/app" />
+              <option name="hostPath" value="$PROJECT_DIR$" />
+            </DockerVolumeBindingImpl>
+          </list>
+        </option>
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/Digipost.Signature.Api.Client.Archive.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Archive.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <IsPackable>false</IsPackable>
+      <TargetFramework>netcoreapp2.1</TargetFramework>
+      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
+++ b/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.*" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
         <PackageReference Include="System.Net.Requests" Version="4.*" />
     </ItemGroup>
 

--- a/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
+++ b/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Archive</Title>
         <PackageId>Digipost.Signature.Api.Client.Archive</PackageId>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
+++ b/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Title>Digipost Signature Api Client Archive</Title>
         <PackageId>Digipost.Signature.Api.Client.Archive</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
+++ b/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Archive</Title>
         <PackageId>Digipost.Signature.Api.Client.Archive</PackageId>
-        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
+++ b/Digipost.Signature.Api.Client.Archive/Digipost.Signature.Api.Client.Archive.csproj
@@ -5,13 +5,9 @@
         <PackageId>Digipost.Signature.Api.Client.Archive</PackageId>
     </PropertyGroup>
 
-
-
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.*" />
         <PackageReference Include="System.Net.Requests" Version="4.*" />
-
-        <PackageReference Include="Digipost.Signature.Api.Client.Core" Version="6.*" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
@@ -3,8 +3,8 @@
     <PackageReference Include="api-client-shared" Version="4.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-      <PackageReference Include="NLog" Version="4.6.7" />
-      <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4" />
+    <PackageReference Include="NLog" Version="4.6.7" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Core.Tests/EnvironmentTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/EnvironmentTests.cs
@@ -22,6 +22,21 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 Assert.Equal(url, environment.Url);
                 Assert.Equal(certificates, environment.AllowedChainCertificates);
             }
+            
+            [Fact]
+            public void Gets_initialize_docker_localhost_environment()
+            {
+                //Arrange
+                var url = new Uri("https://host.docker.internal:8443");
+                var certificates = CertificateChainUtility.FunksjoneltTestmiljøSertifikater();
+
+                //Act
+                var environment = Environment.DockerLocalhost;
+
+                //Assert
+                Assert.Equal(url, environment.Url);
+                Assert.Equal(certificates, environment.AllowedChainCertificates);
+            }
 
             [Fact]
             public void Gets_initialized_difi_qa_environment()

--- a/Digipost.Signature.Api.Client.Core.Tests/Smoke/SmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/Smoke/SmokeTests.cs
@@ -2,6 +2,6 @@
 {
     public class SmokeTests
     {
-        public static Environment Endpoint => Environment.Test;
+        public static Environment Endpoint => Environment.Qa;
     }
 }

--- a/Digipost.Signature.Api.Client.Core/ClientConfiguration.cs
+++ b/Digipost.Signature.Api.Client.Core/ClientConfiguration.cs
@@ -31,7 +31,7 @@ namespace Digipost.Signature.Api.Client.Core
         ///     If set, it will be used for all <see cref="ISignatureJob">SignatureJobs</see> created without a
         ///     <see cref="Sender" />.
         /// </param>
-        public ClientConfiguration(Environment environment, X509Certificate2 certificate, Sender globalSender = null,WebProxy proxy = null, NetworkCredential credential = null)
+        public ClientConfiguration(Environment environment, X509Certificate2 certificate, Sender globalSender = null, WebProxy proxy = null, NetworkCredential credential = null)
         {
             Environment = environment;
             GlobalSender = globalSender;

--- a/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
+++ b/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Core</Title>
         <PackageId>Digipost.Signature.Api.Client.Core</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -25,7 +26,7 @@
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-        <DocumentationFile>bin\Release\netcoreapp2.1\Digipost.Signature.Api.Client.Core.xml</DocumentationFile>
+        <DocumentationFile>bin\Release\$(TargetFramework)\Digipost.Signature.Api.Client.Core.xml</DocumentationFile>
         <noWarn>1591</noWarn>
     </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
+++ b/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Core</Title>
         <PackageId>Digipost.Signature.Api.Client.Core</PackageId>
-        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
+++ b/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
@@ -3,26 +3,26 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Core</Title>
         <PackageId>Digipost.Signature.Api.Client.Core</PackageId>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="api-client-shared" Version="4.0.0"/>
-        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7"/>
-        <PackageReference Include="System.Net.Requests" Version="4.3.0"/>
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="4.6.0"/>
+        <PackageReference Include="api-client-shared" Version="4.0.0" />
+        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+        <PackageReference Include="System.Net.Requests" Version="4.3.0" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="4.6.0" />
 
-        <PackageReference Include="NLog" Version="4.6.7"/>
-        <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0"/>
+        <PackageReference Include="NLog" Version="4.6.7" />
+        <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Resources\Digipost.Signature.Api.Client.Resources.csproj"/>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Scripts\Digipost.Signature.Api.Client.Scripts.csproj"/>
+        <ProjectReference Include="..\Digipost.Signature.Api.Client.Resources\Digipost.Signature.Api.Client.Resources.csproj" />
+        <ProjectReference Include="..\Digipost.Signature.Api.Client.Scripts\Digipost.Signature.Api.Client.Scripts.csproj" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -31,13 +31,13 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-        <None Update="Internal/Xsd/**/*" CopyToOutputDirectory="PreserveNewest"/>
+        <None Update="Internal/Xsd/**/*" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
     <ItemGroup>
-        <None Remove="Internal/Xsd/**/*"/>
+        <None Remove="Internal/Xsd/**/*" />
     </ItemGroup>
     <ItemGroup>
-        <EmbeddedResource Include="Internal/Xsd/**/*"/>
+        <EmbeddedResource Include="Internal/Xsd/**/*" />
     </ItemGroup>
 
 </Project>

--- a/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
+++ b/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
@@ -17,9 +17,6 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0"/>
-
-        <PackageReference Include="Digipost.Signature.Api.Client.Resources" Version="6.*"/>
-        <PackageReference Include="Digipost.Signature.Api.Client.Scripts" Version="6.*"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Core/Environment.cs
+++ b/Digipost.Signature.Api.Client.Core/Environment.cs
@@ -18,6 +18,11 @@ namespace Digipost.Signature.Api.Client.Core
 
         internal static Environment Localhost => new Environment(
             CertificateChainUtility.FunksjoneltTestmiljøSertifikater(),
+            new Uri("https://localhost:8443")
+        );
+        
+        internal static Environment DockerLocalhost => new Environment(
+            CertificateChainUtility.FunksjoneltTestmiljøSertifikater(),
             new Uri("https://host.docker.internal:8443")
         );
 

--- a/Digipost.Signature.Api.Client.Core/Environment.cs
+++ b/Digipost.Signature.Api.Client.Core/Environment.cs
@@ -18,7 +18,7 @@ namespace Digipost.Signature.Api.Client.Core
 
         internal static Environment Localhost => new Environment(
             CertificateChainUtility.FunksjoneltTestmiljøSertifikater(),
-            new Uri("https://localhost:8443")
+            new Uri("https://host.docker.internal:8443")
         );
 
         internal static Environment Qa => new Environment(

--- a/Digipost.Signature.Api.Client.Core/Utilities/LoggingUtility.cs
+++ b/Digipost.Signature.Api.Client.Core/Utilities/LoggingUtility.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NLog.Extensions.Logging;
@@ -24,9 +25,12 @@ namespace Digipost.Signature.Api.Client.Core.Utilities
         private static void SetUpLoggingForTesting(IServiceProvider serviceProvider)
         {
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-
             loggerFactory.AddNLog(new NLogProviderOptions {CaptureMessageTemplates = true, CaptureMessageProperties = true});
-            NLog.LogManager.LoadConfiguration("./../../../../Digipost.Signature.Api.Client.Core/nlog.config");
+            
+            var projectName = new[]{"signature-api-client-dotnet"};
+            var projectParentDirectory = System.AppDomain.CurrentDomain.BaseDirectory.Split(projectName, StringSplitOptions.None)[0];
+            var nLogConfigPath = projectParentDirectory + $"/{projectName.ElementAt(0)}/Digipost.Signature.Api.Client.Core/nlog.config";
+            NLog.LogManager.LoadConfiguration(nLogConfigPath);
         }
 
     }

--- a/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
@@ -4,9 +4,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
@@ -4,9 +4,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.*" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Direct</Title>
         <PackageId>Digipost.Signature.Api.Client.Direct</PackageId>
-        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Direct</Title>
         <PackageId>Digipost.Signature.Api.Client.Direct</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -19,7 +20,7 @@
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-        <DocumentationFile>bin\Release\netcoreapp2.1\Digipost.Signature.Api.Client.Direct.xml</DocumentationFile>
+        <DocumentationFile>bin\Release\$(TargetFramework)\Digipost.Signature.Api.Client.Direct.xml</DocumentationFile>
         <noWarn>1591</noWarn>
     </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.*"/>
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.*"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.*"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0"/>
         <PackageReference Include="System.Net.Requests" Version="4.*"/>
         <PackageReference Include="System.Security.Cryptography.Xml" Version="4.*"/>
         <PackageReference Include="api-client-shared" Version="4.0.0"/>

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -3,20 +3,20 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Direct</Title>
         <PackageId>Digipost.Signature.Api.Client.Direct</PackageId>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.*"/>
-        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.*"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0"/>
-        <PackageReference Include="System.Net.Requests" Version="4.*"/>
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="4.*"/>
-        <PackageReference Include="api-client-shared" Version="4.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.*" />
+        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.*" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+        <PackageReference Include="System.Net.Requests" Version="4.*" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="4.*" />
+        <PackageReference Include="api-client-shared" Version="4.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
+        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -12,8 +12,6 @@
         <PackageReference Include="System.Net.Requests" Version="4.*"/>
         <PackageReference Include="System.Security.Cryptography.Xml" Version="4.*"/>
         <PackageReference Include="api-client-shared" Version="4.0.0"/>
-
-        <PackageReference Include="Digipost.Signature.Api.Client.Core" Version="6.*"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Direct/DirectClient.cs
+++ b/Digipost.Signature.Api.Client.Direct/DirectClient.cs
@@ -128,11 +128,7 @@ namespace Digipost.Signature.Api.Client.Direct
                     return CreateNoContentResponse(requestResult);
                 case HttpStatusCode.OK:
                     return CreateOkResponse(requestContent, requestResult);
-#if NETCOREAPP
-                case HttpStatusCode.TooManyRequests:
-#else
                 case (HttpStatusCode)429:
-#endif
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Direct/DirectClient.cs
+++ b/Digipost.Signature.Api.Client.Direct/DirectClient.cs
@@ -128,7 +128,11 @@ namespace Digipost.Signature.Api.Client.Direct
                     return CreateNoContentResponse(requestResult);
                 case HttpStatusCode.OK:
                     return CreateOkResponse(requestContent, requestResult);
-                case (HttpStatusCode)429: //HttpStatusCode.TooManyRequests
+#if NETCOREAPP
+                case HttpStatusCode.TooManyRequests:
+#else
+                case (HttpStatusCode)429:
+#endif
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Direct/DirectClient.cs
+++ b/Digipost.Signature.Api.Client.Direct/DirectClient.cs
@@ -122,13 +122,13 @@ namespace Digipost.Signature.Api.Client.Direct
 
             _logger.LogDebug($"Requesting status change on endpoint {requestResult.RequestMessage.RequestUri} ...");
 
-            switch (requestResult.StatusCode)
+            switch ((int)requestResult.StatusCode)
             {
-                case HttpStatusCode.NoContent:
+                case 204: //HttpStatusCode.NoContent
                     return CreateNoContentResponse(requestResult);
-                case HttpStatusCode.OK:
+                case 200: //HttpStatusCode.OK
                     return CreateOkResponse(requestContent, requestResult);
-                case HttpStatusCode.TooManyRequests:
+                case 429: //HttpStatusCode.TooManyRequests
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Direct/DirectClient.cs
+++ b/Digipost.Signature.Api.Client.Direct/DirectClient.cs
@@ -122,13 +122,13 @@ namespace Digipost.Signature.Api.Client.Direct
 
             _logger.LogDebug($"Requesting status change on endpoint {requestResult.RequestMessage.RequestUri} ...");
 
-            switch ((int)requestResult.StatusCode)
+            switch (requestResult.StatusCode)
             {
-                case 204: //HttpStatusCode.NoContent
+                case HttpStatusCode.NoContent:
                     return CreateNoContentResponse(requestResult);
-                case 200: //HttpStatusCode.OK
+                case HttpStatusCode.OK:
                     return CreateOkResponse(requestContent, requestResult);
-                case 429: //HttpStatusCode.TooManyRequests
+                case (HttpStatusCode)429: //HttpStatusCode.TooManyRequests
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
+++ b/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="api-client-shared" Version="4.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.*"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0"/>
     <PackageReference Include="NLog" Version="4.6.7"/>
     <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4"/>
   </ItemGroup>

--- a/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
+++ b/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
@@ -1,15 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <PackageReference Include="api-client-shared" Version="4.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.*"/>
-        <PackageReference Include="NLog" Version="4.6.7"/>
-        <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4"/>
-    </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Direct\Digipost.Signature.Api.Client.Direct.csproj"/>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Portal\Digipost.Signature.Api.Client.Portal.csproj"/>
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="api-client-shared" Version="4.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.*"/>
+    <PackageReference Include="NLog" Version="4.6.7"/>
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Direct\Digipost.Signature.Api.Client.Direct.csproj"/>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Portal\Digipost.Signature.Api.Client.Portal.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
+++ b/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
         <PackageReference Include="api-client-shared" Version="4.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.*"/>
         <PackageReference Include="NLog" Version="4.6.7"/>
         <PackageReference Include="NLog.Extensions.Logging" Version="1.5.4"/>
     </ItemGroup>

--- a/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
@@ -20,6 +20,7 @@
     </ItemGroup>
 
     <PropertyGroup>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
@@ -32,7 +32,7 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.Smoke
         {
             var serviceProvider = LoggingUtility.CreateServiceProviderAndSetUpLogging();
             var sender = new Sender(BringPublicOrganizationNumber);
-            var clientConfig = new ClientConfiguration(environment, GetBringCertificate(), sender) {HttpClientTimeoutInMilliseconds = 30000, LogRequestAndResponse = true};
+            var clientConfig = new ClientConfiguration(environment, GetBringCertificate(), sender) {HttpClientTimeoutInMilliseconds = 30000222, LogRequestAndResponse = true};
             var client = new PortalClient(clientConfig, serviceProvider.GetService<ILoggerFactory>());
             return client;
         }

--- a/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
@@ -89,20 +89,5 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.Smoke
             _fixture.TestHelper
                 .Create_job(new Sender(BringPrivateOrganizationNumber), signer);
         }
-
-        [Fact]
-        public void Create_job_with_queue_and_verify_excessive_polling_is_queue_dependent()
-        {
-            var signer = new Signer(new PersonalIdentificationNumber("12345678910"), new Notifications(new Email("email@example.com"))) {OnBehalfOf = OnBehalfOf.Other};
-            var senderWithQueue = new Sender(BringPrivateOrganizationNumber, new PollingQueue("CustomPortalPollingQueue"));
-            var senderWithoutQueue = new Sender(BringPrivateOrganizationNumber);
-
-            _fixture.TestHelper
-                .Create_job(senderWithQueue, signer)
-                .Sign_job()
-                .ExpectJobStatusForSenderIs(NoChanges, senderWithoutQueue)
-                .ExpectJobStatusForSenderIs(CompletedSuccessfully, senderWithQueue)
-                .ExpectJobStatusForSenderIs(NoChanges, senderWithQueue);
-        }
     }
 }

--- a/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
@@ -32,7 +32,7 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.Smoke
         {
             var serviceProvider = LoggingUtility.CreateServiceProviderAndSetUpLogging();
             var sender = new Sender(BringPublicOrganizationNumber);
-            var clientConfig = new ClientConfiguration(environment, GetBringCertificate(), sender) {HttpClientTimeoutInMilliseconds = 30000222, LogRequestAndResponse = true};
+            var clientConfig = new ClientConfiguration(environment, GetBringCertificate(), sender) {HttpClientTimeoutInMilliseconds = 30000, LogRequestAndResponse = true};
             var client = new PortalClient(clientConfig, serviceProvider.GetService<ILoggerFactory>());
             return client;
         }

--- a/Digipost.Signature.Api.Client.Portal.Tests/Smoke/TestHelper.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Smoke/TestHelper.cs
@@ -61,9 +61,11 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.Smoke
             }
 
             var httpResponseMessage = _client.AutoSign((int) _jobResponse.JobId, ((PersonalIdentificationNumber) signer.Identifier).Value).Result;
-            Assert.True(httpResponseMessage.IsSuccessStatusCode, "Signing through API failed. Are you trying to sign a job type " +
+            
+            
+            Assert.True(httpResponseMessage.IsSuccessStatusCode, $"Signing through API failed. Are you trying to sign a job type " +
                                                                  "that we do not offer API signing for? Remember that this is not " +
-                                                                 "possible in production!");
+                                                                 $"possible in production! Error calling {httpResponseMessage.RequestMessage.RequestUri} was {httpResponseMessage} ");
 
             return this;
         }
@@ -208,7 +210,10 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.Smoke
         private void ConfirmExcessReceipt(JobStatusChanged statusChange)
         {
             var uri = TransformReferenceToCorrectEnvironment(statusChange.ConfirmationReference.Url);
-            _client.Confirm(new ConfirmationReference(uri)).Wait();
+            Console.WriteLine($"Confirmation on: {uri} ");
+            _client.Confirm(new ConfirmationReference(uri)).Wait(TimeSpan.FromSeconds(3));
+            Console.WriteLine("Oh so done ...");
+            
         }
 
         private static void Assert_state(object obj)

--- a/Digipost.Signature.Api.Client.Portal.Tests/Smoke/TestHelper.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Smoke/TestHelper.cs
@@ -210,10 +210,7 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.Smoke
         private void ConfirmExcessReceipt(JobStatusChanged statusChange)
         {
             var uri = TransformReferenceToCorrectEnvironment(statusChange.ConfirmationReference.Url);
-            Console.WriteLine($"Confirmation on: {uri} ");
-            _client.Confirm(new ConfirmationReference(uri)).Wait(TimeSpan.FromSeconds(3));
-            Console.WriteLine("Oh so done ...");
-            
+            _client.Confirm(new ConfirmationReference(uri)).Wait();
         }
 
         private static void Assert_state(object obj)

--- a/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
+++ b/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Portal</Title>
         <PackageId>Digipost.Signature.Api.Client.Portal</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,7 +18,7 @@
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-        <DocumentationFile>bin\Release\netcoreapp2.1\Digipost.Signature.Api.Client.Portal.xml</DocumentationFile>
+        <DocumentationFile>bin\Release\$(TargetFramework)\Digipost.Signature.Api.Client.Portal.xml</DocumentationFile>
         <noWarn>1591</noWarn>
     </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
+++ b/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
@@ -3,18 +3,18 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Portal</Title>
         <PackageId>Digipost.Signature.Api.Client.Portal</PackageId>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="api-client-shared" Version="4.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0"/>
+        <PackageReference Include="api-client-shared" Version="4.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
+        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
+++ b/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Portal</Title>
         <PackageId>Digipost.Signature.Api.Client.Portal</PackageId>
-        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
+++ b/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
@@ -10,8 +10,6 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0"/>
-
-        <PackageReference Include="Digipost.Signature.Api.Client.Core" Version="6.*"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Portal/PortalClient.cs
+++ b/Digipost.Signature.Api.Client.Portal/PortalClient.cs
@@ -79,13 +79,13 @@ namespace Digipost.Signature.Api.Client.Portal
 
             _logger.LogDebug($"Requesting status change on endpoint {requestResult.RequestMessage.RequestUri} ...");
 
-            switch (requestResult.StatusCode)
+            switch ((int)requestResult.StatusCode)
             {
-                case HttpStatusCode.NoContent:
+                case 204: //HttpStatusCode.NoContent
                     return CreateNoContentResponse(requestResult);
-                case HttpStatusCode.OK:
+                case 200: //HttpStatusCode.OK
                     return CreateOkResponse(requestContent, requestResult);
-                case HttpStatusCode.TooManyRequests:
+                case 429: //HttpStatusCode.TooManyRequests
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Portal/PortalClient.cs
+++ b/Digipost.Signature.Api.Client.Portal/PortalClient.cs
@@ -85,11 +85,7 @@ namespace Digipost.Signature.Api.Client.Portal
                     return CreateNoContentResponse(requestResult);
                 case HttpStatusCode.OK:
                     return CreateOkResponse(requestContent, requestResult);
-#if NETCOREAPP
-                case HttpStatusCode.TooManyRequests:
-#else
                 case (HttpStatusCode)429:
-#endif
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Portal/PortalClient.cs
+++ b/Digipost.Signature.Api.Client.Portal/PortalClient.cs
@@ -85,7 +85,11 @@ namespace Digipost.Signature.Api.Client.Portal
                     return CreateNoContentResponse(requestResult);
                 case HttpStatusCode.OK:
                     return CreateOkResponse(requestContent, requestResult);
-                case (HttpStatusCode)429: // HttpStatusCode.TooManyRequests
+#if NETCOREAPP
+                case HttpStatusCode.TooManyRequests:
+#else
+                case (HttpStatusCode)429:
+#endif
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Portal/PortalClient.cs
+++ b/Digipost.Signature.Api.Client.Portal/PortalClient.cs
@@ -79,13 +79,13 @@ namespace Digipost.Signature.Api.Client.Portal
 
             _logger.LogDebug($"Requesting status change on endpoint {requestResult.RequestMessage.RequestUri} ...");
 
-            switch ((int)requestResult.StatusCode)
+            switch (requestResult.StatusCode)
             {
-                case 204: //HttpStatusCode.NoContent
+                case HttpStatusCode.NoContent:
                     return CreateNoContentResponse(requestResult);
-                case 200: //HttpStatusCode.OK
+                case HttpStatusCode.OK:
                     return CreateOkResponse(requestContent, requestResult);
-                case 429: //HttpStatusCode.TooManyRequests
+                case (HttpStatusCode)429: // HttpStatusCode.TooManyRequests
                     throw CreateTooManyRequestsException(requestResult);
                 default:
                     throw RequestHelper.HandleGeneralException(requestResult.StatusCode, requestContent);

--- a/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
+++ b/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
+++ b/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
@@ -1,17 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <ItemGroup>
-        <PackageReference Include="Digipost.Signature.Api.Client.Direct" Version="6.*"/>
-        <PackageReference Include="Digipost.Signature.Api.Client.Portal" Version="6.*"/>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Direct\Digipost.Signature.Api.Client.Direct.csproj" />
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Portal\Digipost.Signature.Api.Client.Portal.csproj" />
 
-    <ItemGroup>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core.Tests\Digipost.Signature.Api.Client.Core.Tests.csproj"/>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
-    </ItemGroup>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Core.Tests\Digipost.Signature.Api.Client.Core.Tests.csproj"/>
+    <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
+  </ItemGroup>
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
 
 </Project>

--- a/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
+++ b/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
@@ -1,15 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <ItemGroup>
-        <PackageReference Include="Digipost.Signature.Api.Client.Direct" Version="7.*"/>
-        <PackageReference Include="Digipost.Signature.Api.Client.Portal" Version="7.*"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core.Tests\Digipost.Signature.Api.Client.Core.Tests.csproj"/>
-        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
-    </ItemGroup>
-
+    
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>

--- a/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
+++ b/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <ProjectReference Include="..\Digipost.Signature.Api.Client.Direct\Digipost.Signature.Api.Client.Direct.csproj" />
-    <ProjectReference Include="..\Digipost.Signature.Api.Client.Portal\Digipost.Signature.Api.Client.Portal.csproj" />
+    <ItemGroup>
+        <PackageReference Include="Digipost.Signature.Api.Client.Direct" Version="7.*"/>
+        <PackageReference Include="Digipost.Signature.Api.Client.Portal" Version="7.*"/>
+    </ItemGroup>
 
-    <ProjectReference Include="..\Digipost.Signature.Api.Client.Core.Tests\Digipost.Signature.Api.Client.Core.Tests.csproj"/>
-    <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core.Tests\Digipost.Signature.Api.Client.Core.Tests.csproj"/>
+        <ProjectReference Include="..\Digipost.Signature.Api.Client.Core\Digipost.Signature.Api.Client.Core.csproj"/>
+    </ItemGroup>
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/Digipost.Signature.Api.Client.Program/Program.cs
+++ b/Digipost.Signature.Api.Client.Program/Program.cs
@@ -1,14 +1,20 @@
 ﻿
+using System;
+using Digipost.Signature.Api.Client.Core;
+using Digipost.Signature.Api.Client.Portal;
+using Environment = Digipost.Signature.Api.Client.Core.Environment;
+
 namespace Digipost.Signature.Api.Client.Program
 {
     public class Program
     {
         static void Main(string[] args)
         {
-//            var clientConfiguration = new ClientConfiguration(Environment.Test, certificateReader2.ReadCertificate());
-//            var portalClient = new PortalClient(clientConfiguration);
+            /*var clientConfiguration = new ClientConfiguration(Environment.DifiQa, CertificateReader.ReadCertificate());
+            var portalClient = new PortalClient(clientConfiguration);
 
-//            var result = portalClient.GetRootResource(new Sender("988015814")).Result;
+            var result = portalClient.GetRootResource(new Sender("988015814")).Result;
+            Console.WriteLine(result);*/
         }
     }
 }

--- a/Digipost.Signature.Api.Client.Program/Program.cs
+++ b/Digipost.Signature.Api.Client.Program/Program.cs
@@ -1,9 +1,4 @@
 ﻿
-using System;
-using Digipost.Signature.Api.Client.Core;
-using Digipost.Signature.Api.Client.Portal;
-using Environment = Digipost.Signature.Api.Client.Core.Environment;
-
 namespace Digipost.Signature.Api.Client.Program
 {
     public class Program

--- a/Digipost.Signature.Api.Client.Resources/Digipost.Signature.Api.Client.Resources.csproj
+++ b/Digipost.Signature.Api.Client.Resources/Digipost.Signature.Api.Client.Resources.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Resources</Title>
         <PackageId>Digipost.Signature.Api.Client.Resources</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Scripts/Digipost.Signature.Api.Client.Scripts.csproj
+++ b/Digipost.Signature.Api.Client.Scripts/Digipost.Signature.Api.Client.Scripts.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <Title>Digipost Signature Api Client Scripts</Title>
         <PackageId>Digipost.Signature.Api.Client.Scripts</PackageId>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
     <PropertyGroup>
+        <!--        Common build properties of all projects-->
         <Version>0.0.0.0</Version>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
 
@@ -16,4 +17,19 @@
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     </PropertyGroup>
 
+    <!--    DOCKER BUILD PROPERTIES-->
+    <!--    The following two property groups ensures that container builds does not interfere with IDE builds, -->
+    <!--    by building in a separate directory as described in -->
+    <!--    https://github.com/dotnet/dotnet-docker/blob/master/samples/run-tests-in-sdk-container.md -->
+    <PropertyGroup>
+        <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)/obj/**/*</DefaultItemExcludes>
+        <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)/bin/**/*</DefaultItemExcludes>
+    </PropertyGroup>
+
+
+    <PropertyGroup Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' == 'true'">
+        <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)/obj/container/</BaseIntermediateOutputPath>
+        <BaseOutputPath>$(MSBuildProjectDirectory)/bin/container/</BaseOutputPath>
+    </PropertyGroup>
+    <!--    END DOCKER BUILD PROPERTIES-->
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp2.1</TargetFramework>
 
-        <Version>0.0.0.0</Version>
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+        <Version>6.0.0.0</Version>
+        <AssemblyVersion>6.0.0.0</AssemblyVersion>
 
         <Authors>Digipost AS</Authors>
         <Company>Posten Norge AS</Company>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>6.0.0.0</Version>
-        <AssemblyVersion>6.0.0.0</AssemblyVersion>
+        <Version>0.0.0.0</Version>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
 
         <Authors>Digipost AS</Authors>
         <Company>Posten Norge AS</Company>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
         <Authors>Digipost AS</Authors>
         <Company>Posten Norge AS</Company>
-        <Copyright>Copyright © 2019 Posten Norge AS</Copyright>
+        <Copyright>Copyright © 2020 Posten Norge AS</Copyright>
 
         <PackageProjectUrl>https://github.com/digipost/signature-api-client-dotnet/</PackageProjectUrl>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -16,20 +16,4 @@
         <UserSecretsId>organization-certificate</UserSecretsId>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     </PropertyGroup>
-
-    <!--    DOCKER BUILD PROPERTIES-->
-    <!--    The following two property groups ensures that container builds does not interfere with IDE builds, -->
-    <!--    by building in a separate directory as described in -->
-    <!--    https://github.com/dotnet/dotnet-docker/blob/master/samples/run-tests-in-sdk-container.md -->
-    <PropertyGroup>
-        <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)/obj/**/*</DefaultItemExcludes>
-        <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)/bin/**/*</DefaultItemExcludes>
-    </PropertyGroup>
-
-
-    <PropertyGroup Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' == 'true'">
-        <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)/obj/container/</BaseIntermediateOutputPath>
-        <BaseOutputPath>$(MSBuildProjectDirectory)/bin/container/</BaseOutputPath>
-    </PropertyGroup>
-    <!--    END DOCKER BUILD PROPERTIES-->
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,5 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
-
         <Version>6.0.0.0</Version>
         <AssemblyVersion>6.0.0.0</AssemblyVersion>
 

--- a/docker/tests/Dockerfile
+++ b/docker/tests/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1
+
+WORKDIR /signature-api-client-dotnet
+
+COPY . .
+RUN dotnet restore
+
+RUN mv ./Buypass_Class_3_Test4_CA_3.pem /usr/local/share/ca-certificates/Buypass_Class_3_Test4_CA_3.crt 
+RUN mv ./Buypass_Class_3_Test4_Root_CA.pem /usr/local/share/ca-certificates/Buypass_Class_3_Test4_ROOT_CA.crt 
+
+RUN update-ca-certificates
+
+ENTRYPOINT ["dotnet", "test", "-c", "Release"]


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Endret til å targete .NET Standard 2.0, i stedet for .NET Core. Grunnen til at vi kan gjøre dette nå er .NET Standard fungerer lokalt i MacOS Catalina. Dette betyr at biblioteket kan brukes med .NET Framework <= 4.6.1 og .NET Core <= 2.0 (https://docs.microsoft.com/en-us/dotnet/standard/net-standard).

### 🏆 Interessante highlights

La til mulighet for å kjøre tester i Docker. Man må da ha satt opp sertifikater lokalt først.
