### PR TITLE
Bump api client shared

### DIFF
--- a/Digipost.Signature.Api.Client.Archive.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Archive.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/Digipost.Signature.Api.Client.Archive.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Archive.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
@@ -6,8 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     </ItemGroup>

--- a/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="api-client-shared" Version="4.0.0" />
+    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NLog" Version="4.7.6" />

--- a/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NLog" Version="4.7.6" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.5" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
+++ b/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="api-client-shared" Version="4.0.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
         <PackageReference Include="System.Net.Requests" Version="4.3.0" />
         <PackageReference Include="System.Security.Cryptography.Xml" Version="5.0.0" />

--- a/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="api-client-shared" Version="4.0.0" />
+    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
         <PackageReference Include="System.Net.Requests" Version="4.*" />
         <PackageReference Include="System.Security.Cryptography.Xml" Version="5.0.0" />
-        <PackageReference Include="api-client-shared" Version="4.0.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
+++ b/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="api-client-shared" Version="4.0.0" />
+    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="NLog" Version="4.7.6" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.5" />

--- a/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
         <PackageReference Include="NLog" Version="4.7.6" />
         <PackageReference Include="NLog.Extensions.Logging" Version="1.6.5" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
-        <PackageReference Include="api-client-shared" Version="4.0.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
         <PackageReference Include="NLog" Version="4.7.6" />
         <PackageReference Include="NLog.Extensions.Logging" Version="1.6.5" />

--- a/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
+++ b/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="api-client-shared" Version="4.0.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />

--- a/Digipost.Signature.Api.Client.Resources/Digipost.Signature.Api.Client.Resources.csproj
+++ b/Digipost.Signature.Api.Client.Resources/Digipost.Signature.Api.Client.Resources.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="api-client-shared" Version="4.0.0"/>
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Digipost.Signature.Api.Client.Scripts/Digipost.Signature.Api.Client.Scripts.csproj
+++ b/Digipost.Signature.Api.Client.Scripts/Digipost.Signature.Api.Client.Scripts.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="api-client-shared" Version="4.0.0"/>
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Dockerfile_tests
+++ b/Dockerfile_tests
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 WORKDIR /signature-api-client-dotnet
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+services:
+  tests:
+    build: 
+      context: .
+      dockerfile: Dockerfile_tests
+    volumes:
+      # Smoketest requires some setup. See internal documentation.
+      - $HOME/.microsoft/usersecrets/organization-certificate/secrets.json:/root/.microsoft/usersecrets/organization-certificate/secrets.json:ro
+      - $HOME/Documents/sertifikater/Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12:$HOME/Documents/sertifikater/Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12:ro


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Ta i bruk nyeste api-client-shared . Denne endringen har ingen funksjonelle endringer i seg selv foruten pakkenavn og versjon. Se endringslogg for avhengigheten her: https://github.com/digipost/api-client-shared-dotnet/releases

Dette er et steg på vei for at https://github.com/difi/sikker-digital-post-klient-dotnet/ , https://github.com/difi/felles-utility-dotnet og https://github.com/difi/oppslagstjeneste-klient-dotnet skal avhenge av samme versjon av delte avhengigheter

