### PR TITLE
Upgrade Digipost.Api.Client.Shared to 7.1.2 to support seid2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   release:
@@ -25,17 +25,17 @@ jobs:
       - name: Print assembly version
         run: echo $ASSEMBLY_VERSION
       - name: Pack nupkg
-        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Core
+        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION -p:InformationalVersion=$RELEASE_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Core
       - name: Pack nupkg
-        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Archive
+        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION -p:InformationalVersion=$RELEASE_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Archive
       - name: Pack nupkg
-        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Direct
+        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION -p:InformationalVersion=$RELEASE_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Direct
       - name: Pack nupkg
-        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Portal
+        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION -p:InformationalVersion=$RELEASE_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Portal
       - name: Pack nupkg
-        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Resources
+        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION -p:InformationalVersion=$RELEASE_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Resources
       - name: Pack nupkg
-        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Scripts
+        run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION -p:InformationalVersion=$RELEASE_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Scripts
       - name: Push Client to NuGet
         env:
           NUGET_API_KEY: ${{ secrets.NUGETAPIKEY }}

--- a/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
+    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NLog" Version="4.7.6" />

--- a/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
+++ b/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.2" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
         <PackageReference Include="System.Net.Requests" Version="4.3.0" />
         <PackageReference Include="System.Security.Cryptography.Xml" Version="5.0.0" />

--- a/Digipost.Signature.Api.Client.Core/Internal/UserAgentHandler.cs
+++ b/Digipost.Signature.Api.Client.Core/Internal/UserAgentHandler.cs
@@ -11,16 +11,16 @@ namespace Digipost.Signature.Api.Client.Core.Internal
     {
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            request.Headers.Add("User-Agent", GetAssemblyVersion());
+            request.Headers.Add("User-Agent", GetInformationalVersion());
 
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
-
-        private static string GetAssemblyVersion()
+        
+        private static string GetInformationalVersion()
         {
-            var assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version;
+            var informationalVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
-            return $"posten-signature-api-client-dotnet/{assemblyVersion} (netcore/{GetNetCoreVersion()})";
+            return $"posten-signature-api-client-dotnet/{informationalVersion} (netcore/{GetNetCoreVersion()})";
         }
 
         private static string GetNetCoreVersion()

--- a/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
+    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
         <PackageReference Include="System.Net.Requests" Version="4.*" />
         <PackageReference Include="System.Security.Cryptography.Xml" Version="5.0.0" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
+++ b/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
+    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="NLog" Version="4.7.6" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.5" />

--- a/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
         <PackageReference Include="NLog" Version="4.7.6" />
         <PackageReference Include="NLog.Extensions.Logging" Version="1.6.5" />

--- a/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
+++ b/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.2" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />

--- a/Digipost.Signature.Api.Client.Resources/Digipost.Signature.Api.Client.Resources.csproj
+++ b/Digipost.Signature.Api.Client.Resources/Digipost.Signature.Api.Client.Resources.csproj
@@ -7,22 +7,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.2" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-        <None Update="Xml\Data\**\*" CopyToOutputDirectory="PreserveNewest"/>
-        <None Update="Xsd\Data\**\*" CopyToOutputDirectory="PreserveNewest"/>
-        <None Update="Document\Data\**\*" CopyToOutputDirectory="PreserveNewest"/>
+        <None Update="Xml\Data\**\*" CopyToOutputDirectory="PreserveNewest" />
+        <None Update="Xsd\Data\**\*" CopyToOutputDirectory="PreserveNewest" />
+        <None Update="Document\Data\**\*" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
     <ItemGroup>
-        <None Remove="Xml\Data\**\*"/>
-        <None Remove="Xsd\Data\**\*"/>
-        <None Remove="Document\Data\**\*"/>
+        <None Remove="Xml\Data\**\*" />
+        <None Remove="Xsd\Data\**\*" />
+        <None Remove="Document\Data\**\*" />
     </ItemGroup>
     <ItemGroup>
-        <EmbeddedResource Include="Xml\Data\**\*"/>
-        <EmbeddedResource Include="Xsd\Data\**\*"/>
-        <EmbeddedResource Include="Document\Data\**\*"/>
+        <EmbeddedResource Include="Xml\Data\**\*" />
+        <EmbeddedResource Include="Xsd\Data\**\*" />
+        <EmbeddedResource Include="Document\Data\**\*" />
     </ItemGroup>
 </Project>

--- a/Digipost.Signature.Api.Client.Scripts/Digipost.Signature.Api.Client.Scripts.csproj
+++ b/Digipost.Signature.Api.Client.Scripts/Digipost.Signature.Api.Client.Scripts.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.2" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
Also changed User-agent header to use InformationalVersion that is set to Nuget version
instead of Assembly version, which only changes with major versions.

Brukte denne for å prøve å forstå hva de forskjellige typene versjoner egentlig er: https://saebamini.com/how-to-version-your-net-nuget-packages-libraries-and-assemblies-azure-yaml-pipelines-example-using-net-core-cli/