### PR TITLE
Adds possibility to describe direct signature job

### DIFF
--- a/Digipost.Signature.Api.Client.Direct.Tests/JobTests.cs
+++ b/Digipost.Signature.Api.Client.Direct.Tests/JobTests.cs
@@ -26,9 +26,12 @@ namespace Digipost.Signature.Api.Client.Direct.Tests
                 var documents = DomainUtility.GetSingleDirectDocument();
                 var exitUrls = DomainUtility.GetExitUrls();
                 var sender = CoreDomainUtility.GetSender();
-
+                var description = "Description";
                 //Act
-                var directJob = new Job("Job title", documents, signers, id, exitUrls, sender);
+                var directJob = new Job("Job title", documents, signers, id, exitUrls, sender)
+                {
+                    Description = description
+                };
 
                 //Assert
                 Assert.Equal(id, directJob.Reference);
@@ -36,6 +39,7 @@ namespace Digipost.Signature.Api.Client.Direct.Tests
                 Assert.Equal(documents, directJob.Documents);
                 Assert.Equal(exitUrls, directJob.ExitUrls);
                 Assert.Equal(sender, directJob.Sender);
+                Assert.Equal(description, directJob.Description);
             }
         }
     }

--- a/Digipost.Signature.Api.Client.Direct/Internal/AsicE/DirectAsiceGenerator.cs
+++ b/Digipost.Signature.Api.Client.Direct/Internal/AsicE/DirectAsiceGenerator.cs
@@ -12,7 +12,8 @@ namespace Digipost.Signature.Api.Client.Direct.Internal.AsicE
             var manifest = new Manifest(job.Title, job.Sender, job.Documents, job.Signers)
             {
                 AuthenticationLevel = job.AuthenticationLevel,
-                IdentifierInSignedDocuments = job.IdentifierInSignedDocuments
+                IdentifierInSignedDocuments = job.IdentifierInSignedDocuments,
+                Description = job.Description
             };
             var signature = new SignatureGenerator(certificate, job.Documents, manifest);
 

--- a/Digipost.Signature.Api.Client.Direct/Job.cs
+++ b/Digipost.Signature.Api.Client.Direct/Job.cs
@@ -33,7 +33,7 @@ namespace Digipost.Signature.Api.Client.Direct
 
         public string Title { get; }
 
-        public string Description { get; }
+        public string Description { get; set; }
 
         public IEnumerable<Document> Documents { get; }
 


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Fixed bug that did not allow senders to describe a signature job.

### 👀 Eksempler og screenshots

```c#
var job = new Direct.Job(jobTitle, documentsToSign, signers, reference, exitUrls) {   
    Description =  "Description of signature job",
};
```
