### PR TITLE
Upgrade api-client-shared-dotnet to 7.1.5

### DIFF
--- a/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.4" />
+    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NLog" Version="4.7.13" />

--- a/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
+++ b/Digipost.Signature.Api.Client.Core/Digipost.Signature.Api.Client.Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.4" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
         <PackageReference Include="System.Net.Requests" Version="4.3.0" />
         <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />

--- a/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.4" />
+    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
+++ b/Digipost.Signature.Api.Client.Direct/Digipost.Signature.Api.Client.Direct.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
         <PackageReference Include="System.Net.Requests" Version="4.*" />
         <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.4" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
+++ b/Digipost.Signature.Api.Client.Docs/Digipost.Signature.Api.Client.Docs.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.4" />
+    <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NLog" Version="4.7.13" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />

--- a/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.4" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="NLog" Version="4.7.13" />
         <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />

--- a/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
+++ b/Digipost.Signature.Api.Client.Portal/Digipost.Signature.Api.Client.Portal.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.4" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />

--- a/Digipost.Signature.Api.Client.Resources/Digipost.Signature.Api.Client.Resources.csproj
+++ b/Digipost.Signature.Api.Client.Resources/Digipost.Signature.Api.Client.Resources.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.4" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Digipost.Signature.Api.Client.Scripts/Digipost.Signature.Api.Client.Scripts.csproj
+++ b/Digipost.Signature.Api.Client.Scripts/Digipost.Signature.Api.Client.Scripts.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.4" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
To replace the root certificates from Buypass for test envs.
See https://github.com/digipost/api-client-shared-dotnet/pull/31