### PR TITLE
Version number fixing et al

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 3.1.101
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 8.0.403
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 8.0.403
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ jobs:
         run: echo "ASSEMBLY_VERSION=$(echo ${GITHUB_REF:10} | cut -d '.' -f 1).0.0" >> $GITHUB_ENV
       - name: Print assembly version
         run: echo $ASSEMBLY_VERSION
+      - name: Sed InformationalVersion number for build purposes
+        run: sed -i -e "s|0.0.0.0<\/Version>|$RELEASE_VERSION<\/Version>|g" Directory.Build.props
+      - name: Sed AssemblyVersion number for build purposes
+        run: sed -i -e "s|0.0.0.0<\/AssemblyVersion>>|$RELEASE_VERSION<\/AssemblyVersion>>|g" Directory.Build.props
       - name: Pack nupkg
         run: dotnet pack -p:PackageVersion=$RELEASE_VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION -p:InformationalVersion=$RELEASE_VERSION --configuration Release --no-build --output digipost/packed Digipost.Signature.Api.Client.Core
       - name: Pack nupkg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 8.0.403
       - name: Install dependencies
         run: dotnet restore 
       - name: Decode certificate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
         run: dotnet restore 
       - name: Decode certificate
         run: echo -n $(echo ${{ secrets.ENCODED_SMOKE_TEST_CERTIFICATE }}) | base64 -d > $(echo ${GITHUB_WORKSPACE})/Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12
+      - name: checksum p12 (for debug-purposes)
+        run: sha256sum $(echo ${GITHUB_WORKSPACE})/Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12
       - name: Set certificate path
         run: dotnet user-secrets set Certificate:Path:Absolute $(echo ${GITHUB_WORKSPACE})/Bring_Digital_Signature_Key_Encipherment_Data_Encipherment.p12 --project Digipost.Signature.Api.Client.Core
       - name: Set certificate password

--- a/Digipost.Signature.Api.Client.Archive.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Archive.Tests/Digipost.Signature.Api.Client.Archive.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFramework>netcoreapp3.1</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Core.Tests/BaseClientTests.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/BaseClientTests.cs
@@ -53,7 +53,10 @@ namespace Digipost.Signature.Api.Client.Core.Tests
             {
                 //Arrange
                 var expected = new Sender(BringPublicOrganizationNumber);
-                var clientConfiguration = new ClientConfiguration(Environment.DifiQa, GetBringCertificate(), expected);
+                var clientConfiguration = new ClientConfiguration(Environment.DifiQa, GetBringCertificate(), expected)
+                {
+                    CertificateValidationPreferences = {ValidateSenderCertificate = false}
+                };
                 var client = new ClientStub(clientConfiguration);
 
                 //Act
@@ -69,7 +72,10 @@ namespace Digipost.Signature.Api.Client.Core.Tests
                 //Arrange
                 var expected = new Sender(BringPublicOrganizationNumber);
                 var clientConfigurationSender = new Sender(PostenOrganizationNumber);
-                var clientConfiguration = new ClientConfiguration(Environment.DifiQa, GetBringCertificate(), clientConfigurationSender);
+                var clientConfiguration = new ClientConfiguration(Environment.DifiQa, GetBringCertificate(), clientConfigurationSender)
+                {
+                    CertificateValidationPreferences = {ValidateSenderCertificate = false}
+                };
                 var client = new ClientStub(clientConfiguration);
 
                 //Act
@@ -84,7 +90,10 @@ namespace Digipost.Signature.Api.Client.Core.Tests
             {
                 //Arrange
                 var expected = new Sender(BringPublicOrganizationNumber);
-                var clientConfiguration = new ClientConfiguration(Environment.DifiQa, GetBringCertificate());
+                var clientConfiguration = new ClientConfiguration(Environment.DifiQa, GetBringCertificate())
+                {
+                    CertificateValidationPreferences = {ValidateSenderCertificate = false}
+                };
                 var client = new ClientStub(clientConfiguration);
 
                 //Act

--- a/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Core.Tests/Digipost.Signature.Api.Client.Core.Tests.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Core.Tests/Utilities/CoreDomainUtility.cs
+++ b/Digipost.Signature.Api.Client.Core.Tests/Utilities/CoreDomainUtility.cs
@@ -28,7 +28,10 @@ namespace Digipost.Signature.Api.Client.Core.Tests.Utilities
 
         public static ClientConfiguration GetClientConfiguration()
         {
-            return new ClientConfiguration(Environment.DifiQa, GetBringCertificate(), GetSender());
+            return new ClientConfiguration(Environment.DifiQa, GetBringCertificate(), GetSender())
+            {
+                CertificateValidationPreferences = {ValidateSenderCertificate = false}
+            };
         }
 
         public static Document GetDocument()

--- a/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Digipost.Signature.Api.Client.Direct.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Direct.Tests/Smoke/DirectClientSmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Direct.Tests/Smoke/DirectClientSmokeTests.cs
@@ -28,7 +28,8 @@ namespace Digipost.Signature.Api.Client.Direct.Tests.Smoke
 
             var clientConfig = new ClientConfiguration(environment, GetBringCertificate(), new Sender(BringPublicOrganizationNumber))
             {
-                LogRequestAndResponse = true
+                LogRequestAndResponse = true,
+                CertificateValidationPreferences = {ValidateSenderCertificate = false} 
             };
             var client = new DirectClient(clientConfig, serviceProvider.GetService<ILoggerFactory>());
 

--- a/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Digipost.Signature.Api.Client.Portal.Tests.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/Digipost.Signature.Api.Client.Portal.Tests/PortalClientTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/PortalClientTests.cs
@@ -60,7 +60,10 @@ namespace Digipost.Signature.Api.Client.Portal.Tests
             {
                 //Arrange
                 var sender = new Sender(BringPublicOrganizationNumber);
-                var clientConfiguration = new ClientConfiguration(Environment.DifiQa, GetBringCertificate(), sender);
+                var clientConfiguration = new ClientConfiguration(Environment.DifiQa, GetBringCertificate(), sender)
+                {
+                    CertificateValidationPreferences = {ValidateSenderCertificate = false}
+                };
                 var fakeHttpClientHandlerChecksCorrectSender = new FakeHttpClientHandlerChecksCorrectSenderResponse();
                 var portalClient = new PortalClient(clientConfiguration)
                 {

--- a/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Smoke/PortalClientSmokeTests.cs
@@ -32,7 +32,11 @@ namespace Digipost.Signature.Api.Client.Portal.Tests.Smoke
         {
             var serviceProvider = LoggingUtility.CreateServiceProviderAndSetUpLogging();
             var sender = new Sender(BringPublicOrganizationNumber);
-            var clientConfig = new ClientConfiguration(environment, GetBringCertificate(), sender) {HttpClientTimeoutInMilliseconds = 30000, LogRequestAndResponse = true};
+            var clientConfig = new ClientConfiguration(environment, GetBringCertificate(), sender)
+            {
+                HttpClientTimeoutInMilliseconds = 30000, LogRequestAndResponse = true,
+                CertificateValidationPreferences = {ValidateSenderCertificate = false} 
+            };
             var client = new PortalClient(clientConfig, serviceProvider.GetService<ILoggerFactory>());
             return client;
         }

--- a/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
+++ b/Digipost.Signature.Api.Client.Program/Digipost.Signature.Api.Client.Program.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
     


### PR DESCRIPTION
Like any good PR this does three tings at once ... 

- We do some version bumping of dotnet as well as some pipeline runners
- We disable client side certificate validation (00e49724cbffc22ff95096f0d967ad1312f4f4f7) for tests as we have gone from Buypass-issued certs to Digipost-issued ones. See commit for more information (there is no security implication as everything is validated server-side)
- We manually insert version information to the `Directory.build.props` file that hopefully gets properly embedded into the final build artifact so as to be reflected in the user-agent string of the client. This will allow us to see what version of the client is actually used out there. 

Hopefully we'll get to package a few more dependency bumps and the like soon™