### PR TITLE
Add missing non-sensitive title

### DIFF
--- a/Digipost.Signature.Api.Client.Portal.Tests/Internal/AsicE/PortalAsiceGeneratorTests.cs
+++ b/Digipost.Signature.Api.Client.Portal.Tests/Internal/AsicE/PortalAsiceGeneratorTests.cs
@@ -1,0 +1,52 @@
+using System;
+using Digipost.Signature.Api.Client.Core.Tests.Utilities;
+using Digipost.Signature.Api.Client.Portal.Internal.AsicE;
+using Digipost.Signature.Api.Client.Portal.Tests.Utilities;
+using Xunit;
+
+namespace Digipost.Signature.Api.Client.Portal.Tests.Internal.AsicE
+{
+    public class PortalAsiceGeneratorTests
+    {
+        public class ToManifestMethod : PortalAsiceGeneratorTests
+        {
+            [Fact]
+            public void Creates_manifest_with_expected_attributes()
+            {
+                // Arrange
+                var job = new Job(
+                    "Job title",
+                    DomainUtility.GetSinglePortalDocument(),
+                    DomainUtility.GetSigners(2),
+                    "Reference",
+                    CoreDomainUtility.GetSender())
+                {
+                    Description = "Job description",
+                    NonSensitiveTitle = "Non-sensitive title",
+                    Availability = new Availability
+                    {
+                        Activation = new DateTime(2025, 6, 6),
+                        AvailableFor = TimeSpan.FromDays(7)
+                    },
+                    AuthenticationLevel = Core.Enums.AuthenticationLevel.Four,
+                    IdentifierInSignedDocuments = Core.Enums.IdentifierInSignedDocuments.PersonalIdentificationNumberAndName
+                };
+
+                // Act
+                var manifest = PortalAsiceGenerator.ToManifest(job);
+
+                // Assert
+                Assert.Equal(job.Title, manifest.Title);
+                Assert.Equal(job.Documents, manifest.Documents);
+                Assert.Equal(job.Signers, manifest.Signers);
+                Assert.Equal(job.Sender, manifest.Sender);
+                Assert.Equal(job.Description, manifest.Description);
+                Assert.Equal(job.NonSensitiveTitle, manifest.NonSensitiveTitle);
+                Assert.Equal(job.Availability, manifest.Availability);
+                Assert.Equal(job.AuthenticationLevel, manifest.AuthenticationLevel);
+                Assert.Equal(job.IdentifierInSignedDocuments, manifest.IdentifierInSignedDocuments);
+            }
+        }
+    }
+
+}

--- a/Digipost.Signature.Api.Client.Portal/Internal/AsicE/PortalAsiceGenerator.cs
+++ b/Digipost.Signature.Api.Client.Portal/Internal/AsicE/PortalAsiceGenerator.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
+﻿using System.Security.Cryptography.X509Certificates;
 using Digipost.Signature.Api.Client.Core;
 using Digipost.Signature.Api.Client.Core.Internal.Asice;
 using Digipost.Signature.Api.Client.Core.Internal.Asice.AsiceSignature;
@@ -10,19 +9,25 @@ namespace Digipost.Signature.Api.Client.Portal.Internal.AsicE
     {
         public static DocumentBundle CreateAsice(Job job, X509Certificate2 certificate, IAsiceConfiguration asiceConfiguration)
         {
-            var manifest = new Manifest(job.Title, job.Sender, job.Documents, job.Signers)
-            {
-                Availability = job.Availability,
-                AuthenticationLevel = job.AuthenticationLevel,
-                IdentifierInSignedDocuments = job.IdentifierInSignedDocuments,
-                NonSensitiveTitle = job.NonSensitiveTitle,
-                Description = job.Description
-            };
+            var manifest = ToManifest(job);
 
             var signature = new SignatureGenerator(certificate, job.Documents, manifest);
             var asiceArchive = GetAsiceArchive(job, asiceConfiguration, job.Documents, manifest, signature);
 
             return new DocumentBundle(asiceArchive.GetBytes());
         }
+
+        internal static Manifest ToManifest(Job job)
+        {
+            return new Manifest(job.Title, job.Sender, job.Documents, job.Signers)
+            {
+                Availability = job.Availability,
+                AuthenticationLevel = job.AuthenticationLevel,
+                IdentifierInSignedDocuments = job.IdentifierInSignedDocuments,
+                Description = job.Description,
+                NonSensitiveTitle = job.NonSensitiveTitle
+            };
+        }
     }
+
 }


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Manifest is part of document bundle sent to the server.

A Portal.Job object might be newed up with a non-sensitive title, but this was lost in the mapping from Portal.Job to Manifest. This resulted in a bug which made it impossible for consumers of our dotnet client library to create portal jobs with non-sensitive tiles.

Non-sensitive titles are titles that may be added in addition to "regular" titles. Non-sensitive titles may be displayed in contexts where we cannot ensure that people viewing are authorized, such as in email notificaitons sent to signers.




### 🏆 Interessante highlights

_Usikkerheter, avveininger og andre ting som kan være interessant å se på_



### 🤷‍♀️ Anbefalt fremgangsmåte

_Hvordan bør pull requesten angripes? Commit for commit? Hele smæla på en gang? Gjennomgang i fellesskap IRL?_



### 👀 Eksempler og screenshots

_Har du gjort en API-endring? Vis et request! Har du endret i GUI? Ta et screenshot!_



### ⚙️ Avhengigheter 

_Er koden avhengig av en endring i for eksempel frontend eller API-klienten? Sleng inn en link til relevante pull requests her_


### 🚔 Sikkerhet

_Hvordan er de viktigste sikkerhetsaspektene ivaretatt? Her er det lov til å slette ting som ikke er relevante, men det er kjempeviktig at du har vurdert relevansen av alt!_

* Autentisering og autorisasjon
* Datasanitering (XSS, SQL injection, …)
* Trengs det risikovurdering?
* Sikring av tilgang til data; tillater vi noen å aksessere data hos oss? Hvordan er i så fall det sikret?
* Har vi innført nye tredjepartsrammeverk? Hvor trygge er vi på sikkerheten i disse?